### PR TITLE
Merge from upstream

### DIFF
--- a/Midas/src/c-compiler/metal/readjson.cpp
+++ b/Midas/src/c-compiler/metal/readjson.cpp
@@ -221,8 +221,8 @@ VariableId* readVariableId(MetalCache* cache, const json& variable) {
 
   int number = variable["number"];
   std::string maybeName;
-  if (variable["name"]["__type"] == "Some") {
-    maybeName = variable["name"]["value"];
+  if (variable["optName"]["__type"] == "Some") {
+    maybeName = variable["optName"]["value"];
   }
 
   return makeIfNotPresent(

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/VonHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/VonHammer.scala
@@ -381,7 +381,7 @@ object VonHammer {
           Vector(
             VonMember("sourceExpr", vonifyNode(sourceExpr)),
             VonMember("local", vonifyLocal(local)),
-            VonMember("name", vonifyOptional[FullNameH](name, n => VonStr(n.toString())))))
+            VonMember("optName", vonifyOptional[FullNameH](name, n => VonStr(n.toString())))))
       }
       case UnstackifyH(local) => {
         VonObject(
@@ -667,7 +667,7 @@ object VonHammer {
       Vector(
         VonMember("number", VonInt(number)),
         VonMember(
-          "name",
+          "optName",
           vonifyOptional[FullNameH](maybeName, x => VonStr(x.toString())))))
   }
 


### PR DESCRIPTION
…e. Also changed some JSON "" to "__type" and some "name" to "optName" for easier loading.

* Vale code can now export structs, interfaces, and functions other than main

* Fixed struct and interfaces exporting

* Changed type field from empty string to __type, for easier reading

* Changed name to optName in some of the nodes to be more parseable to C#