### PR TITLE
Finished terrain generation for BenchmarkRL-vale (#45)

### DIFF
--- a/Midas/.gitignore
+++ b/Midas/.gitignore
@@ -90,6 +90,7 @@ packages
 # Build output
 valec
 test/test_build
+test/Driver.jar
 
 # python
 __pycache__

--- a/Midas/src/c-compiler/function/expressions/shared/shared.cpp
+++ b/Midas/src/c-compiler/function/expressions/shared/shared.cpp
@@ -189,7 +189,7 @@ void buildAssert(
   buildIf(
       functionState, builder, isZeroLE(builder, conditionLE),
       [from, globalState, functionState, failMessage](LLVMBuilderRef thenBuilder) {
-        buildFlare(from, globalState, functionState, thenBuilder, failMessage, " Exiting!");
+        buildPrint(globalState, thenBuilder, failMessage + " Exiting!\n");
         auto exitCodeIntLE = LLVMConstInt(LLVMInt8Type(), 255, false);
         LLVMBuildCall(thenBuilder, globalState->exit, &exitCodeIntLE, 1, "");
       });

--- a/Midas/src/c-compiler/globalstate.h
+++ b/Midas/src/c-compiler/globalstate.h
@@ -31,6 +31,8 @@ public:
   Program* program;
   LLVMValueRef objIdCounter;
   LLVMValueRef liveHeapObjCounter;
+  LLVMValueRef derefCounter;
+  LLVMValueRef mutRcAdjustCounter;
   LLVMValueRef malloc, free, assert, exit, assertI64Eq, flareI64, printCStr,
       getch, printInt, printBool, initStr, addStr, eqStr, printVStr, intToCStr,
       strlen, censusContains, censusAdd, censusRemove, panic;

--- a/Midas/src/c-compiler/vale.cpp
+++ b/Midas/src/c-compiler/vale.cpp
@@ -209,13 +209,19 @@ void compileValeCode(GlobalState* globalState, const char* filename) {
 
   globalState->liveHeapObjCounter =
       LLVMAddGlobal(globalState->mod, LLVMInt64Type(), "__liveHeapObjCounter");
-//  LLVMSetLinkage(globalState->liveHeapObjCounter, LLVMExternalLinkage);
   LLVMSetInitializer(globalState->liveHeapObjCounter, LLVMConstInt(LLVMInt64Type(), 0, false));
 
   globalState->objIdCounter =
       LLVMAddGlobal(globalState->mod, LLVMInt64Type(), "__objIdCounter");
-//  LLVMSetLinkage(globalState->liveHeapObjCounter, LLVMExternalLinkage);
   LLVMSetInitializer(globalState->objIdCounter, LLVMConstInt(LLVMInt64Type(), 501, false));
+
+  globalState->derefCounter =
+      LLVMAddGlobal(globalState->mod, LLVMInt64Type(), "derefCounter");
+  LLVMSetInitializer(globalState->derefCounter, LLVMConstInt(LLVMInt64Type(), 0, false));
+
+  globalState->mutRcAdjustCounter =
+      LLVMAddGlobal(globalState->mod, LLVMInt64Type(), "__mutRcAdjustCounter");
+  LLVMSetInitializer(globalState->mutRcAdjustCounter, LLVMConstInt(LLVMInt64Type(), 0, false));
 
   initInternalStructs(globalState);
   initInternalExterns(globalState);

--- a/Midas/src/c-compiler/valeopts.cpp
+++ b/Midas/src/c-compiler/valeopts.cpp
@@ -40,7 +40,8 @@ enum
     OPT_WIDTH,
     OPT_IMMERR,
     OPT_VERIFY,
-    OPT_FLARES,
+  OPT_FLARES,
+  OPT_FASTMODE,
     OPT_FILENAMES,
     OPT_CHECKTREE,
     OPT_EXTFUN,
@@ -79,6 +80,7 @@ static opt_arg_t args[] =
 
     { "verbose", 'V', OPT_ARG_REQUIRED, OPT_VERBOSE },
     { "flares", '\0', OPT_ARG_NONE, OPT_FLARES },
+    { "fastmode", '\0', OPT_ARG_NONE, OPT_FASTMODE },
     { "ir", '\0', OPT_ARG_NONE, OPT_IR },
     { "asm", '\0', OPT_ARG_NONE, OPT_ASM },
     { "llvmir", '\0', OPT_ARG_NONE, OPT_LLVMIR },
@@ -205,6 +207,7 @@ int valeOptSet(ValeOptions *opt, int *argc, char **argv) {
         case OPT_VERIFY: opt->verify = 1; break;
 
         case OPT_FLARES: opt->flares = 1; break;
+        case OPT_FASTMODE: opt->fastmode = 1; break;
 
         default: usage(); return -1;
         }

--- a/Midas/src/c-compiler/valeopts.h
+++ b/Midas/src/c-compiler/valeopts.h
@@ -32,6 +32,7 @@ typedef struct ValeOptions {
     bool docs;            // Generate code documentation
     bool census;    // Enable census checking
     bool flares;    // Enable flare output
+    bool fastmode;    // Fast mode, no constraint ref counters!
 } ValeOptions;
 
 int valeOptSet(ValeOptions *opt, int *argc, char **argv);

--- a/Midas/src/valestd/assert.c
+++ b/Midas/src/valestd/assert.c
@@ -11,7 +11,7 @@ void __vassert(char value) {
 
 void __vassertI64Eq(int64_t expected, int64_t actual) {
   if (expected != actual) {
-    printf("Assertion failed! Expected %d but was %d.", expected, actual);
+    printf("Assertion failed! Expected %d but was %d.\n", expected, actual);
     exit(255);
   }
 }

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/ExpressionAstronomer.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/ExpressionAstronomer.scala
@@ -63,17 +63,17 @@ object ExpressionAstronomer {
         val exprA = translateExpression(env, astrouts, exprS)
         GlobalMutateAE(Astronomer.translateImpreciseName(name), exprA)
       }
-      case LocalMutateSE(nameS, exprS) => {
+      case LocalMutateSE(range, nameS, exprS) => {
         val exprA = translateExpression(env, astrouts, exprS)
-        LocalMutateAE(Astronomer.translateVarNameStep(nameS), exprA)
+        LocalMutateAE(range, Astronomer.translateVarNameStep(nameS), exprA)
       }
       case LendSE(innerExprS, targetOwnership) => {
         val innerExprA = translateExpression(env, astrouts, innerExprS)
         LendAE(innerExprA, targetOwnership)
       }
-      case ReturnSE(innerExprS) => {
+      case ReturnSE(range, innerExprS) => {
         val innerExprA = translateExpression(env, astrouts, innerExprS)
-        (ReturnAE(innerExprA))
+        (ReturnAE(range, innerExprA))
       }
       case blockS @ BlockSE(_, _) => translateBlock(env, astrouts, blockS)
       case ArgLookupSE(index) => (ArgLookupAE(index))
@@ -135,8 +135,8 @@ object ExpressionAstronomer {
         // We don't translate the templexes, we can't until we know what the template expects.
         TemplateSpecifiedLookupAE(name, templateArgsS)
       }
-      case LocalLoadSE(name, borrow) => {
-        LocalLoadAE(Astronomer.translateVarNameStep(name), borrow)
+      case LocalLoadSE(range, name, borrow) => {
+        LocalLoadAE(range, Astronomer.translateVarNameStep(name), borrow)
       }
       case FunctionLoadSE(range, name) => {
         FunctionLoadAE(range, Astronomer.translateGlobalFunctionFamilyName(name))

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/Forwarders.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/Forwarders.scala
@@ -58,6 +58,6 @@ object Forwarders {
               FunctionCallAE(
                 RangeS.internal(-35),
                 FunctionLoadAE(RangeS.internal(-35), GlobalFunctionFamilyNameA(callee)),
-                params.map(param => LocalLoadAE(CodeVarNameA(param._1), OwnP))))))))
+                params.map(param => LocalLoadAE(RangeS.internal(-35), CodeVarNameA(param._1), OwnP))))))))
   }
 }

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/arrays.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/arrays.scala
@@ -71,9 +71,10 @@ object Arrays {
               LocalVariableA(CodeVarNameA("generator"), FinalP, NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed)),
             List(
               ConstructArrayAE(
+                RangeS.internal(-56),
                 RuneAT(RangeS.internal(-56),CodeRuneA("T"), CoordTemplataType),
-                LocalLoadAE(CodeVarNameA("size"), OwnP),
-                LocalLoadAE(CodeVarNameA("generator"), OwnP),
+                LocalLoadAE(RangeS.internal(-56),CodeVarNameA("size"), OwnP),
+                LocalLoadAE(RangeS.internal(-56),CodeVarNameA("generator"), OwnP),
                 mutability))))))
   }
 }

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/refcounting.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/builtins/refcounting.scala
@@ -38,14 +38,14 @@ object RefCounting {
               LocalVariableA(CodeVarNameA("num"), FinalP, NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed)),
             List(
               CheckRefCountAE(
-                LocalLoadAE(CodeVarNameA("obj"), OwnP),
+                LocalLoadAE(RangeS.internal(-35), CodeVarNameA("obj"), OwnP),
                 VariableRefCount,
                 FunctionCallAE(
                   RangeS.internal(-42),
                   // We add 1 because that "obj" is also a borrow ref
                   FunctionLoadAE(RangeS.internal(-38),GlobalFunctionFamilyNameA("+")),
                   List(
-                    LocalLoadAE(CodeVarNameA("num"), OwnP),
+                    LocalLoadAE(RangeS.internal(-35), CodeVarNameA("num"), OwnP),
                     IntLiteralAE(1)))),
               VoidAE())))))
 
@@ -80,6 +80,6 @@ object RefCounting {
               LocalVariableA(CodeVarNameA("obj"), FinalP, NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed),
               LocalVariableA(CodeVarNameA("num"), FinalP, NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed)),
             List(
-              CheckRefCountAE(LocalLoadAE(CodeVarNameA("obj"), OwnP), MemberRefCount, LocalLoadAE(CodeVarNameA("num"), OwnP)),
+              CheckRefCountAE(LocalLoadAE(RangeS.internal(-35), CodeVarNameA("obj"), OwnP), MemberRefCount, LocalLoadAE(RangeS.internal(-35), CodeVarNameA("num"), OwnP)),
               VoidAE())))))
 }

--- a/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/expressions.scala
+++ b/Valestrom/Astronomer/src/net/verdagon/vale/astronomer/expressions.scala
@@ -23,7 +23,7 @@ case class WhileAE(condition: BlockAE, body: BlockAE) extends IExpressionAE
 
 case class ExprMutateAE(mutatee: IExpressionAE, expr: IExpressionAE) extends IExpressionAE
 case class GlobalMutateAE(name: IImpreciseNameStepA, expr: IExpressionAE) extends IExpressionAE
-case class LocalMutateAE(name: IVarNameA, expr: IExpressionAE) extends IExpressionAE
+case class LocalMutateAE(range: RangeS, name: IVarNameA, expr: IExpressionAE) extends IExpressionAE
 
 case class LendAE(innerExpr1: IExpressionAE, targetOwnership: OwnershipP) extends IExpressionAE {
   targetOwnership match {
@@ -33,7 +33,7 @@ case class LendAE(innerExpr1: IExpressionAE, targetOwnership: OwnershipP) extend
 }
 case class LockWeakAE(range: RangeS, innerExpr1: IExpressionAE) extends IExpressionAE
 
-case class ReturnAE(innerExpr1: IExpressionAE) extends IExpressionAE
+case class ReturnAE(range: RangeS, innerExpr1: IExpressionAE) extends IExpressionAE
 
 
 //case class CurriedFuncH(closureExpr: ExpressionH, funcName: String) extends ExpressionH
@@ -78,6 +78,7 @@ case class BlockAE(
 //  args: List[IExpressionAE]) extends IExpressionAE
 
 case class ConstructArrayAE(
+    range: RangeS,
     typeTemplex: ITemplexA,
     sizeExpr: IExpressionAE,
     generatorExpr: IExpressionAE,
@@ -127,7 +128,7 @@ case class FunctionCallAE(range: RangeS, callableExpr: IExpressionAE, argsExprs1
 case class TemplateSpecifiedLookupAE(name: String, templateArgs: List[ITemplexS]) extends IExpressionAE
 case class RuneLookupAE(rune: IRuneA, tyype: ITemplataType) extends IExpressionAE
 
-case class LocalLoadAE(name: IVarNameA, targetOwnership: OwnershipP) extends IExpressionAE
+case class LocalLoadAE(range: RangeS, name: IVarNameA, targetOwnership: OwnershipP) extends IExpressionAE
 case class FunctionLoadAE(range: RangeS, name: GlobalFunctionFamilyNameA) extends IExpressionAE
 
 case class UnletAE(name: String) extends IExpressionAE

--- a/Valestrom/Carpenter/test/net/verdagon/vale/carpenter/CarpenterTests.scala
+++ b/Valestrom/Carpenter/test/net/verdagon/vale/carpenter/CarpenterTests.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FunSuite, Matchers}
 
 class CarpenterTests extends FunSuite with Matchers {
 //  test("Function param has virtual") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I {}
 //        |fn doThing(i: virtual I) {4}
@@ -23,7 +23,7 @@ class CarpenterTests extends FunSuite with Matchers {
 //  // There is no doAThing which takes in a MyInterface, so there should be no
 //  // virtual shenanigans going on.
 //  test("No virtual/override/abstract means no function families") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface MyInterface { }
 //        |
@@ -42,7 +42,7 @@ class CarpenterTests extends FunSuite with Matchers {
 //
 //  // Make sure we generate a covariant family for doAThing.
 //  test("Function with virtual makes a function family") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface MyInterface {
 //        |  fn doAThing(i: virtual MyInterface):();
@@ -68,7 +68,7 @@ class CarpenterTests extends FunSuite with Matchers {
 //
 //
 //  test("Unrelated structs don't share function families") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface MyInterface<T> { }
 //        |fn doThing<T>(x: virtual MyInterface<T>) {}
@@ -101,7 +101,7 @@ class CarpenterTests extends FunSuite with Matchers {
 //
 //
 //  test("Functions with same signatures for different ancestors") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |interface J<T> { }
@@ -128,7 +128,7 @@ class CarpenterTests extends FunSuite with Matchers {
 //
 //
 //  test("Virtual function is added to overridden families and gets its own family") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |interface J<T> { }
@@ -156,7 +156,7 @@ class CarpenterTests extends FunSuite with Matchers {
 //
 //
 //  test("Struct is stamped and function families created") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |
@@ -187,7 +187,7 @@ class CarpenterTests extends FunSuite with Matchers {
 //  // Make sure it keeps doAThing and doBThing separate, even though they have the same signatures.
 //  // This tripped up the superfamilycarpenter once when it forgot to compare the names.
 //  test("Functions with same params but different name dont share families") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface MyInterface<T> { }
 //        |struct MyStruct<T> { }

--- a/Valestrom/Driver/src/net/verdagon/vale/driver/Compilation.scala
+++ b/Valestrom/Driver/src/net/verdagon/vale/driver/Compilation.scala
@@ -12,27 +12,33 @@ import net.verdagon.vale.{Err, Ok, vassert, vfail, vwat}
 import net.verdagon.vale.vivem.{Heap, PrimitiveReferendV, ReferenceV, Vivem}
 import net.verdagon.von.IVonData
 
-class Compilation(code: String, verbose: Boolean = true) {
-  val filenamesAndSources = List(("in.vale", code))
+object Compilation {
+  def apply(code: String, verbose: Boolean = true): Compilation = new Compilation(List(("in.vale", code)), verbose)
+}
 
-  var parsedCache: Option[FileP] = None
+class Compilation(filenamesAndSources: List[(String, String)], verbose: Boolean = true) {
+  var parsedsCache: Option[List[FileP]] = None
   var scoutputCache: Option[ProgramS] = None
   var astroutsCache: Option[ProgramA] = None
   var temputsCache: Option[Temputs] = None
   var hinputsCache: Option[Hinputs] = None
   var hamutsCache: Option[ProgramH] = None
 
-  def getParsed(): FileP = {
-    parsedCache match {
-      case Some(parsed) => parsed
+  def getParseds(): List[FileP] = {
+    parsedsCache match {
+      case Some(parseds) => parseds
       case None => {
-        Parser.runParserForProgramAndCommentRanges(code) match {
-          case ParseFailure(err) => vwat(err.toString)
-          case ParseSuccess((program0, _)) => {
-            parsedCache = Some(program0)
-            program0
-          }
-        }
+        parsedsCache =
+          Some(
+            filenamesAndSources.map({ case (filename, source) =>
+              Parser.runParserForProgramAndCommentRanges(source) match {
+                case ParseFailure(err) => vwat(err.toString)
+                case ParseSuccess((program0, _)) => {
+                  program0
+                }
+              }
+            }))
+        parsedsCache.get
       }
     }
   }
@@ -41,7 +47,7 @@ class Compilation(code: String, verbose: Boolean = true) {
     scoutputCache match {
       case Some(scoutput) => scoutput
       case None => {
-        val scoutput = Scout.scoutProgram(List(getParsed()))
+        val scoutput = Scout.scoutProgram(getParseds())
         scoutputCache = Some(scoutput)
         scoutput
       }

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/ExpressionHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/ExpressionHammer.scala
@@ -236,13 +236,13 @@ object ExpressionHammer {
         (loadedAccessH, deferreds)
       }
 
-      case lookup2 @ LocalLookup2(AddressibleLocalVariable2(_, _, _), _) => {
+      case lookup2 @ LocalLookup2(_,AddressibleLocalVariable2(_, _, _), _) => {
         val loadBoxAccess =
           LoadHammer.translateLocalAddress(hinputs, hamuts, locals, lookup2)
         (loadBoxAccess, List())
       }
 
-      case lookup2 @ AddressMemberLookup2(_, _, _) => {
+      case lookup2 @ AddressMemberLookup2(_,_, _, _) => {
         val (loadBoxAccess, deferreds) =
           LoadHammer.translateMemberAddress(hinputs, hamuts, locals, lookup2)
         (loadBoxAccess, deferreds)

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/Hammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/Hammer.scala
@@ -69,7 +69,7 @@ case class Locals(
     tyype: ReferenceH[ReferendH]):
   (Locals, Local) = {
     if (templarLocals.contains(varId2)) {
-      vfail("wot")
+      vfail("There's already a templar local named: " + varId2)
     }
     val newLocalIdNumber = locals.size
     val varIdNameH = NameHammer.translateFullName(hinputs, hamuts, varId2)

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/LoadHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/LoadHammer.scala
@@ -22,24 +22,24 @@ object LoadHammer {
 
     val (loadedAccessH, sourceDeferreds) =
       sourceExpr2 match {
-        case LocalLookup2(ReferenceLocalVariable2(varId, variability, reference), varType2) => {
+        case LocalLookup2(_,ReferenceLocalVariable2(varId, variability, reference), varType2) => {
           vassert(reference == varType2)
           translateMundaneLocalLoad(hinputs, hamuts, locals, varId, reference, targetOwnership)
         }
-        case LocalLookup2(AddressibleLocalVariable2(varId, variability, localReference2), varType2) => {
+        case LocalLookup2(_,AddressibleLocalVariable2(varId, variability, localReference2), varType2) => {
           vassert(localReference2 == varType2)
           translateAddressibleLocalLoad(hinputs, hamuts, locals, varId, variability, localReference2, targetOwnership)
         }
-        case ReferenceMemberLookup2(structExpr2, memberName, memberType2) => {
+        case ReferenceMemberLookup2(_,structExpr2, memberName, memberType2) => {
           translateMundaneMemberLoad(hinputs, hamuts, locals, structExpr2, memberType2, memberName, targetOwnership)
         }
-        case AddressMemberLookup2(structExpr2, memberName, memberType2) => {
+        case AddressMemberLookup2(_,structExpr2, memberName, memberType2) => {
           translateAddressibleMemberLoad(hinputs, hamuts, locals, structExpr2, memberName, memberType2, targetOwnership)
         }
-        case UnknownSizeArrayLookup2(arrayExpr2, arrayType, indexExpr2) => {
+        case UnknownSizeArrayLookup2(_,arrayExpr2, arrayType, indexExpr2) => {
           translateMundaneUnknownSizeArrayLoad(hinputs, hamuts, locals, arrayExpr2, indexExpr2, targetOwnership)
         }
-        case ArraySequenceLookup2(arrayExpr2, arrayType, indexExpr2) => {
+        case ArraySequenceLookup2(_,arrayExpr2, arrayType, indexExpr2) => {
           translateMundaneKnownSizeArrayLoad(hinputs, hamuts, locals, arrayExpr2, indexExpr2, targetOwnership)
         }
       }
@@ -282,7 +282,7 @@ object LoadHammer {
       locals: LocalsBox,
       lookup2: LocalLookup2):
   (ExpressionH[ReferendH]) = {
-    val LocalLookup2(localVar, type2) = lookup2;
+    val LocalLookup2(_,localVar, type2) = lookup2;
     vassert(type2 == localVar.reference)
 
     val local = locals.get(localVar.id).get
@@ -305,7 +305,7 @@ object LoadHammer {
       locals: LocalsBox,
       lookup2: AddressMemberLookup2):
   (ExpressionH[ReferendH], List[Expression2]) = {
-    val AddressMemberLookup2(structExpr2, memberName, resultType2) = lookup2;
+    val AddressMemberLookup2(_,structExpr2, memberName, resultType2) = lookup2;
 
     val (structResultLine, structDeferreds) =
       translate(hinputs, hamuts, locals, structExpr2);

--- a/Valestrom/Hammer/src/net/verdagon/vale/hammer/MutateHammer.scala
+++ b/Valestrom/Hammer/src/net/verdagon/vale/hammer/MutateHammer.scala
@@ -26,22 +26,22 @@ object MutateHammer {
 
     val (oldValueAccess, destinationDeferreds) =
       destinationExpr2 match {
-        case LocalLookup2(ReferenceLocalVariable2(varId, variability, reference), varType2) => {
+        case LocalLookup2(_,ReferenceLocalVariable2(varId, variability, reference), varType2) => {
           translateMundaneLocalMutate(hinputs, hamuts, locals, sourceExprResultLine, varId)
         }
-        case LocalLookup2(AddressibleLocalVariable2(varId, variability, reference), varType2) => {
+        case LocalLookup2(_,AddressibleLocalVariable2(varId, variability, reference), varType2) => {
           translateAddressibleLocalMutate(hinputs, hamuts, locals, sourceExprResultLine, sourceResultPointerTypeH, varId, variability, reference)
         }
-        case ReferenceMemberLookup2(structExpr2, memberName, memberType2) => {
+        case ReferenceMemberLookup2(_,structExpr2, memberName, memberType2) => {
           translateMundaneMemberMutate(hinputs, hamuts, locals, sourceExprResultLine, structExpr2, memberName)
         }
-        case AddressMemberLookup2(structExpr2, memberName, memberType2) => {
+        case AddressMemberLookup2(_,structExpr2, memberName, memberType2) => {
           translateAddressibleMemberMutate(hinputs, hamuts, locals, sourceExprResultLine, structExpr2, memberName)
         }
-        case ArraySequenceLookup2(arrayExpr2, arrayType, indexExpr2) => {
+        case ArraySequenceLookup2(_,arrayExpr2, arrayType, indexExpr2) => {
           translateMundaneKnownSizeArrayMutate(hinputs, hamuts, locals, sourceExprResultLine, arrayExpr2, indexExpr2)
         }
-        case UnknownSizeArrayLookup2(arrayExpr2, arrayType, indexExpr2) => {
+        case UnknownSizeArrayLookup2(_,arrayExpr2, arrayType, indexExpr2) => {
           translateMundaneUnknownSizeArrayMutate(hinputs, hamuts, locals, sourceExprResultLine, arrayExpr2, indexExpr2)
         }
       }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ArithmeticTestsA.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ArithmeticTestsA.scala
@@ -13,7 +13,7 @@ import org.scalatest.{FunSuite, Matchers}
 
 class ArithmeticTestsA extends FunSuite with Matchers {
   test("Dividing") {
-    val compile = new Compilation("fn main(){5 / 2}")
+    val compile = Compilation("fn main(){5 / 2}")
     compile.evalForReferend(Vector()) shouldEqual VonInt(2)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayListTest.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayListTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FunSuite, Matchers}
 
 class ArrayListTest extends FunSuite with Matchers {
   test("Simple ArrayList, no optionals") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct List<E> rules(E Ref) {
         |  array Array<mut, E>;
@@ -52,7 +52,10 @@ class ArrayListTest extends FunSuite with Matchers {
   }
 
   test("Array list with optionals") {
-    val compile = new Compilation(
+    val compile = Compilation(
+      Samples.get("utils.vale") +
+      Samples.get("castutils.vale") +
+      Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
       Samples.get("genericvirtuals/optingarraylist.vale") +
       """
@@ -78,7 +81,10 @@ class ArrayListTest extends FunSuite with Matchers {
   }
 
   test("Array list zero-constructor") {
-    val compile = new Compilation(
+    val compile = Compilation(
+      Samples.get("utils.vale") +
+        Samples.get("castutils.vale") +
+        Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
         Samples.get("genericvirtuals/optingarraylist.vale") +
         """
@@ -96,7 +102,7 @@ class ArrayListTest extends FunSuite with Matchers {
   }
 
   test("Array list len") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
         Samples.get("genericvirtuals/optingarraylist.vale") +
         """
@@ -114,7 +120,10 @@ class ArrayListTest extends FunSuite with Matchers {
   }
 
   test("Array list set") {
-    val compile = new Compilation(
+    val compile = Compilation(
+      Samples.get("utils.vale") +
+        Samples.get("printutils.vale") +
+        Samples.get("castutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
         Samples.get("genericvirtuals/optingarraylist.vale") +
         """
@@ -133,7 +142,10 @@ class ArrayListTest extends FunSuite with Matchers {
   }
 
   test("Array list with optionals with mutable element") {
-    val compile = new Compilation(
+    val compile = Compilation(
+      Samples.get("utils.vale") +
+        Samples.get("printutils.vale") +
+        Samples.get("castutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
       Samples.get("genericvirtuals/optingarraylist.vale") +
         """
@@ -160,7 +172,7 @@ class ArrayListTest extends FunSuite with Matchers {
   }
 
   test("Mutate mutable from in lambda") {
-    val compile = new Compilation(
+    val compile = Compilation(
         """
           |struct Marine { hp int; }
           |
@@ -183,7 +195,7 @@ class ArrayListTest extends FunSuite with Matchers {
   }
 
   test("Move mutable from in lambda") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
       """
         |struct Marine { hp int; }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ArrayTests.scala
@@ -11,7 +11,7 @@ import net.verdagon.vale.driver.Compilation
 
 class ArrayTests extends FunSuite with Matchers {
   test("Simple arraysequence and compiletime index lookup") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  a = [2, 3, 4, 5, 6];
@@ -33,7 +33,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Returning array from function and dotting it") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn makeArray() { [2, 3, 4, 5, 6] }
         |fn main() {
@@ -45,7 +45,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Simple arraysequence and runtime index lookup") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  i = 2;
@@ -56,7 +56,7 @@ class ArrayTests extends FunSuite with Matchers {
 
     val temputs = compile.getTemputs()
     temputs.lookupFunction("main").only({
-      case ArraySequenceLookup2(_, _, _) => {
+      case ArraySequenceLookup2(_,_, _, _) => {
       }
     })
 
@@ -64,7 +64,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Take arraysequence as a parameter") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn doThings(arr [5 * int]) {
         |  arr.3
@@ -79,7 +79,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Borrow arraysequence as a parameter") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct MutableStruct {
         |  x int;
@@ -98,7 +98,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Simple array map") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  a = Array<imm, int>(10, &IFunction1<imm, int, int>({_}));
@@ -116,7 +116,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Array map taking a closure which captures something") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  x = 7;
@@ -124,7 +124,7 @@ class ArrayTests extends FunSuite with Matchers {
         |  = a.3;
         |}
       """.stripMargin)
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |struct MyIntFunctor { x: Int; }
 //        |impl IFunction1<mut, int, int> for MyIntFunctor;
@@ -139,7 +139,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Simple array map with runtime index lookup") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  a = Array<imm, int>(10, &IFunction1<imm, int, int>({_}));
@@ -147,7 +147,7 @@ class ArrayTests extends FunSuite with Matchers {
         |  = a[i];
         |}
       """.stripMargin)
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |struct MyIntIdentity {}
 //        |impl IFunction1<mut, int, int> for MyIntIdentity;
@@ -164,7 +164,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Nested array") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  = [[2]].0.0;
@@ -176,7 +176,7 @@ class ArrayTests extends FunSuite with Matchers {
 
 
   test("Two dimensional array") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  board =
@@ -194,7 +194,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Array with capture") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct IntBox {
         |  i int;
@@ -216,7 +216,7 @@ class ArrayTests extends FunSuite with Matchers {
 
   // Known failure 2020-08-11
   test("Arr helper with capture") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn Arr<M, F>(n int, generator &F) Array<M, T>
         |rules(M Mutability, T Ref, Prot("__call", (&F, int), T))
@@ -244,7 +244,7 @@ class ArrayTests extends FunSuite with Matchers {
 
 
   test("Mutate array") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  arr = Array<mut, int>(3, &IFunction1<imm, int, int>((row){row}));
@@ -252,7 +252,7 @@ class ArrayTests extends FunSuite with Matchers {
         |  = arr.1;
         |}
       """.stripMargin)
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |struct MyIntIdentity {}
 //        |impl IFunction1<mut, int, int> for MyIntIdentity;
@@ -269,7 +269,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Capture mutable array") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct MyIntIdentity {}
         |impl IFunction1<mut, int, int> for MyIntIdentity;
@@ -288,7 +288,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Swap out of array") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Goblin { }
         |
@@ -308,7 +308,7 @@ class ArrayTests extends FunSuite with Matchers {
 
 
   test("Test array length") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  a = Array<mut, int>(11, &IFunction1<imm, int, int>({_}));
@@ -319,7 +319,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Map using array construct") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  board = Array<mut, int>(5, IFunction1<imm, int, int>((x){x}));
@@ -330,7 +330,7 @@ class ArrayTests extends FunSuite with Matchers {
         |  = result.2;
         |}
       """.stripMargin)
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |struct MyIntIdentity {}
 //        |impl IFunction1<mut, int, int> for MyIntIdentity;
@@ -360,7 +360,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Map from hardcoded values") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """fn toArray<M, N, E>(seq &[<_> N * E]) rules(M Mutability) {
         |  Array<M, E>(N, &IFunction1<imm, int, int>((i){ seq[i]}))
         |}
@@ -372,7 +372,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Nested imm arrays") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("generics/arrayutils.vale") +
       """fn main() {
         |  [[6, 60].toArray<imm>(), [4, 40].toArray<imm>(), [3, 30].toArray<imm>()].toArray<imm>()[2][1]
@@ -383,7 +383,7 @@ class ArrayTests extends FunSuite with Matchers {
 
   // Known failure 2020-08-05
   test("Array foreach") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("generics/arrayutils.vale") +
       """fn main() {
         |  sum = 0;
@@ -395,7 +395,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
   test("Array has") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("generics/arrayutils.vale") +
         """fn main() {
           |  [6, 60, 103].has(103)
@@ -405,7 +405,7 @@ class ArrayTests extends FunSuite with Matchers {
   }
 
 //  test("Destroy lambda with mutable captures") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      Samples.get("generics/arrayutils.vale") +
 //        """
 //          |fn main() {
@@ -429,7 +429,7 @@ class ArrayTests extends FunSuite with Matchers {
 
 
 //  test("Map using map()") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |fn map
 //        |:(n: Int, T: reference, F: referend)

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/BlockTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/BlockTests.scala
@@ -10,7 +10,7 @@ import net.verdagon.vale.driver.Compilation
 
 class BlockTests extends FunSuite with Matchers {
   test("Empty block") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  block {
@@ -25,7 +25,7 @@ class BlockTests extends FunSuite with Matchers {
     compile.evalForReferend(Vector()) shouldEqual VonInt(3)
   }
   test("Simple block with a variable") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  block {
@@ -45,7 +45,7 @@ class BlockTests extends FunSuite with Matchers {
     compile.evalForReferend(Vector()) shouldEqual VonInt(3)
   }
   test("Simple block with a variable, another variable outside with same name") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  block {

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ClosureTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ClosureTests.scala
@@ -92,7 +92,7 @@ class ClosureTests extends FunSuite with Matchers {
     // the environment in the closure has to match this; the environment has
     // to have a borrow reference instead of an owning reference.
 
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine {
         |  hp int;
@@ -107,7 +107,7 @@ class ClosureTests extends FunSuite with Matchers {
   }
 
   test("Test closure's local variables") {
-    val compile = new Compilation("fn main() { x = 4; = {x}(); }")
+    val compile = Compilation("fn main() { x = 4; = {x}(); }")
     val temputs = compile.getTemputs()
 
     temputs.lookupLambdaIn("main").variables match {
@@ -124,7 +124,7 @@ class ClosureTests extends FunSuite with Matchers {
   }
 
   test("Test returning a nonmutable closured variable from the closure") {
-    val compile = new Compilation("fn main() { x = 4; = {x}(); }")
+    val compile = Compilation("fn main() { x = 4; = {x}(); }")
     val temputs = compile.getTemputs()
 
     // The struct should have an int x in it which is a reference type.
@@ -139,7 +139,7 @@ class ClosureTests extends FunSuite with Matchers {
     // Make sure we're doing a referencememberlookup, since it's a reference member
     // in the closure struct.
     lambda.only({
-      case ReferenceMemberLookup2(_, FullName2(_, CodeVarName2("x")), _) =>
+      case ReferenceMemberLookup2(_,_, FullName2(_, CodeVarName2("x")), _) =>
     })
 
     // Make sure there's a function that takes in the closured vars struct, and returns an int
@@ -166,14 +166,14 @@ class ClosureTests extends FunSuite with Matchers {
     main.onlyOf(classOf[FunctionCall2])
 
     lambda.only({
-      case LocalLookup2(ReferenceLocalVariable2(FullName2(_,ClosureParamName2()),Final,_),_) =>
+      case LocalLookup2(_,ReferenceLocalVariable2(FullName2(_,ClosureParamName2()),Final,_),_) =>
     })
 
     compile.evalForReferend(Vector()) shouldEqual VonInt(4)
   }
 
   test("Mutates from inside a closure") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  x! = 4;
@@ -191,7 +191,7 @@ class ClosureTests extends FunSuite with Matchers {
     val lambda = temputs.lookupLambdaIn("main")
     lambda.only({
       case Mutate2(
-        AddressMemberLookup2(_,FullName2(List(FunctionName2("main",List(),List()), LambdaCitizenName2(_)),CodeVarName2("x")),Coord(Share,Int2())),
+        AddressMemberLookup2(_,_,FullName2(List(FunctionName2("main",List(),List()), LambdaCitizenName2(_)),CodeVarName2("x")),Coord(Share,Int2())),
         _) =>
     })
 
@@ -207,7 +207,7 @@ class ClosureTests extends FunSuite with Matchers {
   }
 
   test("Mutates from inside a closure inside a closure") {
-    val compile = new Compilation("fn main() { x! = 4; { { mut x = x + 1; }(); }(); = x; }")
+    val compile = Compilation("fn main() { x! = 4; { { mut x = x + 1; }(); }(); = x; }")
 
     compile.evalForReferend(Vector()) shouldEqual VonInt(5)
   }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/ConjunctionTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/ConjunctionTests.scala
@@ -6,12 +6,12 @@ import org.scalatest.{FunSuite, Matchers}
 
 class ConjunctionTests extends FunSuite with Matchers {
   test("And") {
-    val compile = new Compilation("fn main(){true and true}")
+    val compile = Compilation("fn main(){true and true}")
     compile.evalForReferend(Vector()) shouldEqual VonBool(true)
   }
 
   test("Or") {
-    val compile = new Compilation("fn main(){true or false}")
+    val compile = Compilation("fn main(){true or false}")
     compile.evalForReferend(Vector()) shouldEqual VonBool(true)
   }
 }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/HammerTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/HammerTests.scala
@@ -12,7 +12,7 @@ class HammerTests extends FunSuite with Matchers {
   // The generated nodes will be tested by end-to-end tests.
 
   test("Simple main") {
-    val compile = new Compilation(
+    val compile = Compilation(
       "fn main(){3}")
     val hamuts = compile.getHamuts()
 
@@ -22,7 +22,7 @@ class HammerTests extends FunSuite with Matchers {
 
 //  // Make sure a ListNode struct made it out
 //  test("Templated struct makes it into hamuts") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |struct ListNode<T> imm rules(T: Ref) {
 //        |  tail: *ListNode<T>;
@@ -34,7 +34,7 @@ class HammerTests extends FunSuite with Matchers {
 //  }
 
   test("Two templated structs make it into hamuts") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface MyOption<T> imm rules(T Ref) { }
         |struct MyNone<T> imm rules(T Ref) { }
@@ -59,7 +59,7 @@ class HammerTests extends FunSuite with Matchers {
   // Maybe we can turn off tree shaking?
   // Maybe this just violates requirements?
   test("Virtual and override functions make it into hamuts") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface Blark imm { }
         |fn wot(virtual b *Blark) int abstract;
@@ -76,7 +76,7 @@ class HammerTests extends FunSuite with Matchers {
   }
 
   test("Tests stripping things after panic") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() int {
         |  panic();
@@ -95,7 +95,7 @@ class HammerTests extends FunSuite with Matchers {
 
 
   test("Tests export function") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn moo() export { 42 }
         |""".stripMargin)
@@ -105,7 +105,7 @@ class HammerTests extends FunSuite with Matchers {
   }
 
   test("Tests export struct") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Moo export { }
         |""".stripMargin)
@@ -115,7 +115,7 @@ class HammerTests extends FunSuite with Matchers {
   }
 
   test("Tests export interface") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface Moo export { }
         |""".stripMargin)

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/HashMapTest.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/HashMapTest.scala
@@ -8,8 +8,31 @@ import org.scalatest.{FunSuite, Matchers}
 import net.verdagon.vale.driver.Compilation
 
 class HashMapTest extends FunSuite with Matchers {
+  test("Hash map update") {
+    val compile = Compilation(
+      Samples.get("castutils.vale") +
+        Samples.get("printutils.vale") +
+        Samples.get("genericvirtuals/opt.vale") +
+        Samples.get("genericvirtuals/optingarraylist.vale") +
+        Samples.get("genericvirtuals/hashmap.vale") +
+        Samples.get("utils.vale") +
+        """
+          |fn main() {
+          |  m = HashMap<int, int>({_}, ==);
+          |  m.add(0, 100);
+          |  m.add(4, 101);
+          |  m.add(8, 102);
+          |  m.add(12, 103);
+          |  m.update(8, 108);
+          |  = m.get(8).get();
+          |}
+      """.stripMargin)
+
+    compile.evalForReferend(Vector()) shouldEqual VonInt(108)
+  }
+
   test("Hash map collisions") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -52,7 +75,7 @@ class HashMapTest extends FunSuite with Matchers {
   }
 
   test("Hash map with functors") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -75,7 +98,7 @@ class HashMapTest extends FunSuite with Matchers {
   }
 
   test("Hash map with struct as key") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
       Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -114,7 +137,7 @@ class HashMapTest extends FunSuite with Matchers {
   }
 
   test("Hash map has") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -143,7 +166,7 @@ class HashMapTest extends FunSuite with Matchers {
   }
 
   test("Hash map keys") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -170,8 +193,36 @@ class HashMapTest extends FunSuite with Matchers {
     compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
   }
 
+  test("Hash map values") {
+    val compile = Compilation(
+      Samples.get("castutils.vale") +
+        Samples.get("printutils.vale") +
+        Samples.get("genericvirtuals/opt.vale") +
+        Samples.get("genericvirtuals/optingarraylist.vale") +
+        Samples.get("genericvirtuals/hashmap.vale") +
+        Samples.get("utils.vale") +
+        """
+          |fn main() {
+          |  m = HashMap<int, int>(IFunction1<mut, int, int>({_}), ==);
+          |  m.add(0, 100);
+          |  m.add(4, 101);
+          |  m.add(8, 102);
+          |  m.add(12, 103);
+          |  k = m.values();
+          |  assertEq(k.len(), 4);
+          |  assertEq(k[0], 100);
+          |  assertEq(k[1], 101);
+          |  assertEq(k[2], 102);
+          |  assertEq(k[3], 103);
+          |  = 1337;
+          |}
+        """.stripMargin)
+
+    compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
+  }
+
   test("Hash map with mutable values") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -201,7 +252,7 @@ class HashMapTest extends FunSuite with Matchers {
   }
 
   test("Hash map remove") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -223,6 +274,37 @@ class HashMapTest extends FunSuite with Matchers {
           |  assert(m.has(4));
           |  m.remove(4);
           |  assert(not m.has(4));
+          |  = 1337;
+          |}
+        """.stripMargin)
+
+    compile.evalForReferend(Vector()) shouldEqual VonInt(1337)
+  }
+
+  test("Hash map remove 2") {
+    val compile = Compilation(
+      Samples.get("castutils.vale") +
+        Samples.get("printutils.vale") +
+        Samples.get("genericvirtuals/opt.vale") +
+        Samples.get("genericvirtuals/optingarraylist.vale") +
+        Samples.get("genericvirtuals/hashmap.vale") +
+        Samples.get("utils.vale") +
+        """
+          |fn main() {
+          |  m = HashMap<int, int>(IFunction1<mut, int, int>({_}), ==);
+          |  m.add(0, 0);
+          |  m.add(1, 1);
+          |  m.add(2, 2);
+          |  m.add(3, 3);
+          |  m.remove(1);
+          |  m.remove(2);
+          |  m.add(4, 4);
+          |
+          |  values = m.values();
+          |  assertEq(values.len(), 3, "wat");
+          |  assertEq(values[0], 0, "wat");
+          |  assertEq(values[1], 3, "wat");
+          |  assertEq(values[2], 4, "wat");
           |  = 1337;
           |}
         """.stripMargin)

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/HashSetTest.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/HashSetTest.scala
@@ -5,8 +5,58 @@ import net.verdagon.von.VonInt
 import org.scalatest.{FunSuite, Matchers}
 
 class HashSetTest extends FunSuite with Matchers {
-  test("Hash set has") {
+  test("Hash set from KSA") {
     val compile = new Compilation(
+      List(
+        ("castutils.vale" -> Samples.get("castutils.vale")),
+        ("printutils.vale" -> Samples.get("printutils.vale")),
+        ("generics/arrayutils.vale" -> Samples.get("generics/arrayutils.vale")),
+        ("genericvirtuals/opt.vale" -> Samples.get("genericvirtuals/opt.vale")),
+        ("genericvirtuals/optingarraylist.vale" -> Samples.get("genericvirtuals/optingarraylist.vale")),
+        ("genericvirtuals/hashset.vale" -> Samples.get("genericvirtuals/hashset.vale")),
+        ("utils.vale" -> Samples.get("utils.vale")),
+        ("in.vale" ->
+          """
+            |fn main() {
+            |  m = HashSet<int>([0, 4, 8, 12], IFunction1<mut, int, int>({_}), ==);
+            |  assert(m.has(0));
+            |  assert(m.has(4));
+            |  assert(m.has(8));
+            |  assert(m.has(12));
+            |  = 111;
+            |}
+          """.stripMargin)))
+
+    compile.evalForReferend(Vector()) shouldEqual VonInt(111)
+  }
+
+  test("Hash set from Array") {
+    val compile = new Compilation(
+      List(
+        ("castutils.vale" -> Samples.get("castutils.vale")),
+        ("printutils.vale" -> Samples.get("printutils.vale")),
+        ("generics/arrayutils.vale" -> Samples.get("generics/arrayutils.vale")),
+        ("genericvirtuals/opt.vale" -> Samples.get("genericvirtuals/opt.vale")),
+        ("genericvirtuals/optingarraylist.vale" -> Samples.get("genericvirtuals/optingarraylist.vale")),
+        ("genericvirtuals/hashset.vale" -> Samples.get("genericvirtuals/hashset.vale")),
+        ("utils.vale" -> Samples.get("utils.vale")),
+        ("in.vale" ->
+          """
+            |fn main() {
+            |  m = HashSet<int>([0, 4, 8, 12].toArray<imm>(), IFunction1<mut, int, int>({_}), ==);
+            |  assert(m.has(0));
+            |  assert(m.has(4));
+            |  assert(m.has(8));
+            |  assert(m.has(12));
+            |  = 111;
+            |}
+          """.stripMargin)))
+
+    compile.evalForReferend(Vector()) shouldEqual VonInt(111)
+  }
+
+  test("Hash set has") {
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -34,8 +84,8 @@ class HashSetTest extends FunSuite with Matchers {
     compile.evalForReferend(Vector()) shouldEqual VonInt(111)
   }
 
-  test("Hash set keys") {
-    val compile = new Compilation(
+  test("Hash set toArray") {
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
@@ -49,7 +99,7 @@ class HashSetTest extends FunSuite with Matchers {
           |  m.add(4);
           |  m.add(8);
           |  m.add(12);
-          |  k = m.keys();
+          |  k = m.toArray();
           |  assertEq(k.len(), 4);
           |  assertEq(k[0], 0);
           |  assertEq(k[1], 4);
@@ -63,7 +113,7 @@ class HashSetTest extends FunSuite with Matchers {
   }
 
   test("Hash set remove") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/IfTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/IfTests.scala
@@ -9,7 +9,7 @@ import net.verdagon.vale.driver.Compilation
 
 class IfTests extends FunSuite with Matchers {
   test("Simple true branch returning an int") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  = if (true) { 3 } else { 5 }
@@ -26,7 +26,7 @@ class IfTests extends FunSuite with Matchers {
   }
 
   test("Simple false branch returning an int") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  = if (false) { 3 } else { 5 }
@@ -37,7 +37,7 @@ class IfTests extends FunSuite with Matchers {
   }
 
   test("Ladder") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  = if (false) { 3 } else if (true) { 5 } else { 7 }
@@ -60,7 +60,7 @@ class IfTests extends FunSuite with Matchers {
   }
 
   test("Moving from inside if") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine { x int; }
         |fn main() {
@@ -90,7 +90,7 @@ class IfTests extends FunSuite with Matchers {
   }
 
   test("If with complex condition") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine { x int; }
         |fn main() {
@@ -109,7 +109,7 @@ class IfTests extends FunSuite with Matchers {
   }
 
   test("Ret from inside if will destroy locals") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """struct Marine { hp int; }
         |fn destructor(marine Marine) void {
         |  println("Destroying marine!");
@@ -136,7 +136,7 @@ class IfTests extends FunSuite with Matchers {
   }
 
   test("Can continue if other branch would have returned") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """struct Marine { hp int; }
         |fn destructor(marine Marine) void {
         |  println("Destroying marine!");
@@ -164,7 +164,7 @@ class IfTests extends FunSuite with Matchers {
   }
 
   test("Destructure inside if") {
-    val compile = new Compilation(
+    val compile = Compilation(
 
       """
         |struct Bork {

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/InferTemplateTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/InferTemplateTests.scala
@@ -9,7 +9,7 @@ import net.verdagon.vale.driver.Compilation
 
 class InferTemplateTests extends FunSuite with Matchers {
   test("Test inferring a borrowed argument") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Muta { hp int; }
         |fn moo<T>(m &T) { m.hp }

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/IntegrationTestsA.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/IntegrationTestsA.scala
@@ -18,74 +18,74 @@ import scala.util.Try
 
 class IntegrationTestsA extends FunSuite with Matchers {
   test("Simple program returning an int") {
-    val compile = new Compilation("fn main(){3}")
+    val compile = Compilation("fn main(){3}")
     compile.evalForReferend(Vector()) shouldEqual VonInt(3)
   }
 
   test("Hardcoding negative numbers") {
-    val compile = new Compilation("fn main(){-3}")
+    val compile = Compilation("fn main(){-3}")
     compile.evalForReferend(Vector()) shouldEqual VonInt(-3)
   }
 
   test("Taking an argument and returning it") {
-    val compile = new Compilation("fn main(a int){a}")
+    val compile = Compilation("fn main(a int){a}")
     compile.evalForReferend(Vector(IntV(5))) shouldEqual VonInt(5)
   }
 
   test("Tests adding two numbers") {
-    val compile = new Compilation("fn main(){ +(2, 3) }")
+    val compile = Compilation("fn main(){ +(2, 3) }")
     compile.evalForReferend(Vector()) shouldEqual VonInt(5)
   }
 
   test("Tests adding two floats") {
-    val compile = new Compilation("fn main(){ +(2.5, 3.5) }")
+    val compile = Compilation("fn main(){ +(2.5, 3.5) }")
     compile.evalForReferend(Vector()) shouldEqual VonFloat(6.0f)
   }
 
   test("Tests inline adding") {
-    val compile = new Compilation("fn main(){ 2 + 3 }")
+    val compile = Compilation("fn main(){ 2 + 3 }")
     compile.evalForReferend(Vector()) shouldEqual VonInt(5)
   }
 
   test("Test constraint ref") {
-    val compile = new Compilation(Samples.get("constraintRef.vale"))
+    val compile = Compilation(Samples.get("constraintRef.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(8)
   }
 
   test("Tests inline adding more") {
-    val compile = new Compilation("fn main(){ 2 + 3 + 4 + 5 + 6 }")
+    val compile = Compilation("fn main(){ 2 + 3 + 4 + 5 + 6 }")
     compile.evalForReferend(Vector()) shouldEqual VonInt(20)
   }
 
   test("Simple lambda") {
-    val compile = new Compilation("fn main(){{7}()}")
+    val compile = Compilation("fn main(){{7}()}")
     compile.evalForReferend(Vector()) shouldEqual VonInt(7)
   }
 
   test("Lambda with one magic arg") {
-    val compile = new Compilation("fn main(){{_}(3)}")
+    val compile = Compilation("fn main(){{_}(3)}")
     compile.evalForReferend(Vector()) shouldEqual VonInt(3)
   }
 
 
   // Test that the lambda's arg is the right type, and the name is right
   test("Lambda with a type specified param") {
-    val compile = new Compilation("fn main(){(a int){ +(a,a)}(3)}");
+    val compile = Compilation("fn main(){(a int){ +(a,a)}(3)}");
     compile.evalForReferend(Vector()) shouldEqual VonInt(6)
   }
 
   test("Test overloads") {
-    val compile = new Compilation(Samples.get("functions/overloads.vale"))
+    val compile = Compilation(Samples.get("functions/overloads.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(6)
   }
 
   test("Test block") {
-    val compile = new Compilation("fn main(){true; 200; = 300;}")
+    val compile = Compilation("fn main(){true; 200; = 300;}")
     compile.evalForReferend(Vector()) shouldEqual VonInt(300)
   }
 
   test("Test templates") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn ~<T>(a T, b T) T { a }
         |fn main(){true ~ false; 2 ~ 2; = 3 ~ 3;}
@@ -94,17 +94,17 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Test mutating a local var") {
-    val compile = new Compilation("fn main(){a! = 3; mut a = 4; }")
+    val compile = Compilation("fn main(){a! = 3; mut a = 4; }")
     compile.run(Vector())
   }
 
   test("Test returning a local mutable var") {
-    val compile = new Compilation("fn main(){a! = 3; mut a = 4; = a;}")
+    val compile = Compilation("fn main(){a! = 3; mut a = 4; = a;}")
     compile.evalForReferend(Vector()) shouldEqual VonInt(4)
   }
 
   test("Test taking a callable param") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn do(callable) {callable()}
         |fn main() {do({ 3 })}
@@ -113,7 +113,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Stamps an interface template via a function parameter") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface MyInterface<T> rules(T Ref) { }
         |fn doAThing<T>(i MyInterface<T>) { }
@@ -136,12 +136,12 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Tests unstackifying a variable multiple times in a function") {
-    val compile = new Compilation(Samples.get("multiUnstackify.vale"))
+    val compile = Compilation(Samples.get("multiUnstackify.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(42)
   }
 
   test("Reads a struct member") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct MyStruct { a int; }
         |fn main() { ms = MyStruct(7); = ms.a; }
@@ -151,7 +151,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
 
   // Known failure 2020-08-05
   test("Tests virtual doesn't get called if theres a better override") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface MyOption { }
         |
@@ -190,7 +190,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Tests single expression and single statement functions' returns") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct MyThing { value int; }
         |fn moo() { MyThing(4) }
@@ -200,7 +200,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Tests calling a templated struct's constructor") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct MySome<T> rules(T Ref) { value T; }
         |fn main() {
@@ -211,7 +211,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Test int generic") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |
         |struct Vec<N, T> rules(N int)
@@ -228,28 +228,28 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Tests upcasting from a struct to an interface") {
-    val compile = new Compilation(Samples.get("virtuals/upcasting.vale"))
+    val compile = Compilation(Samples.get("virtuals/upcasting.vale"))
     compile.run(Vector())
   }
 
   test("Tests from file") {
-    val compile = new Compilation(Samples.get("lambdas/doubleclosure.vale"))
+    val compile = Compilation(Samples.get("lambdas/doubleclosure.vale"))
     compile.run(Vector())
   }
 
   test("Tests from subdir file") {
-    val compile = new Compilation(Samples.get("virtuals/round.vale"))
+    val compile = Compilation(Samples.get("virtuals/round.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(8)
   }
 
   test("Tests calling a virtual function") {
-    val compile = new Compilation(Samples.get("virtuals/calling.vale"))
+    val compile = Compilation(Samples.get("virtuals/calling.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(7)
   }
 
   test("Tests making a variable with a pattern") {
     // Tests putting MyOption<int> as the type of x.
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface MyOption<T> rules(T Ref) { }
         |
@@ -270,7 +270,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
 
 
   test("Tests a linked list") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       Samples.get("virtuals/ordinarylinkedlist.vale"))
@@ -278,7 +278,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Tests a templated linked list") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
         Samples.get("genericvirtuals/templatedlinkedlist.vale"))
@@ -286,12 +286,12 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Tests calling an abstract function") {
-    val compile = new Compilation(Samples.get("genericvirtuals/callingAbstract.vale"))
+    val compile = Compilation(Samples.get("genericvirtuals/callingAbstract.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(4)
   }
 
   test("Template overrides are stamped") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
         Samples.get("genericvirtuals/templatedoption.vale"))
@@ -299,7 +299,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Tests a foreach for a linked list") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
         Samples.get("genericvirtuals/foreachlinkedlist.vale"))
@@ -313,18 +313,18 @@ class IntegrationTestsA extends FunSuite with Matchers {
   // So, this checks that it and its three ancestors are all stamped and all get their own
   // function families.
   test("Stamp multiple ancestors") {
-    val compile = new Compilation(Samples.get("genericvirtuals/stampMultipleAncestors.vale"))
+    val compile = Compilation(Samples.get("genericvirtuals/stampMultipleAncestors.vale"))
     val temputs = compile.getTemputs()
     compile.evalForReferend(Vector())
   }
 
   test("Tests recursion") {
-    val compile = new Compilation(Samples.get("functions/recursion.vale"))
+    val compile = Compilation(Samples.get("functions/recursion.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(120)
   }
 
   test("Tests floats") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Moo imm {
         |  x float;
@@ -337,13 +337,13 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("getOr function") {
-    val compile = new Compilation(Samples.get("genericvirtuals/getOr.vale"))
+    val compile = Compilation(Samples.get("genericvirtuals/getOr.vale"))
 
     compile.evalForReferend(Vector()) shouldEqual VonInt(9)
   }
 
   test("Function return without ret upcasts") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface Opt { }
         |struct Some { value int; }
@@ -369,7 +369,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Function return with ret upcasts") {
-    val compile = new Compilation(Samples.get("virtuals/retUpcast.vale"))
+    val compile = Compilation(Samples.get("virtuals/retUpcast.vale"))
 
     val temputs = compile.getTemputs()
     val doIt = temputs.lookupFunction("doIt")
@@ -381,7 +381,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Map function") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
         Samples.get("genericvirtuals/mapFunc.vale"))
@@ -393,7 +393,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   test("Test shaking") {
     // Make sure that functions that cant be called by main will not be included.
 
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       """
@@ -416,7 +416,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   test("Test generic array func") {
     // Make sure that functions that cant be called by main will not be included.
 
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn Arr<M, F>(n int, generator &F) Array<M, T>
         |rules(M Mutability, T Ref, Prot("__call", (&F, int), T))
@@ -437,7 +437,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   test("Test returning empty seq") {
     // Make sure that functions that cant be called by main will not be included.
 
-    val compile = new Compilation(
+    val compile = Compilation(
       """fn main() [] {
         |  []
         |}
@@ -448,7 +448,7 @@ class IntegrationTestsA extends FunSuite with Matchers {
   }
 
   test("Test export functions") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """fn moo() export {
         |  42
         |}

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/OptTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/OptTests.scala
@@ -9,7 +9,10 @@ import net.verdagon.vale.driver.Compilation
 
 class OptTests extends FunSuite with Matchers {
   test("Test empty and get for Some") {
-    val compile = new Compilation(
+    val compile = Compilation(
+      Samples.get("utils.vale") +
+        Samples.get("printutils.vale") +
+        Samples.get("castutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
         """
           |fn main() {
@@ -23,7 +26,10 @@ class OptTests extends FunSuite with Matchers {
   }
 
   test("Test empty and get for None") {
-    val compile = new Compilation(
+    val compile = Compilation(
+      Samples.get("utils.vale") +
+        Samples.get("printutils.vale") +
+        Samples.get("castutils.vale") +
       Samples.get("genericvirtuals/opt.vale") +
         """
           |fn main() {

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/OwnershipTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/OwnershipTests.scala
@@ -14,7 +14,7 @@ import net.verdagon.vale.driver.Compilation
 
 class OwnershipTests extends FunSuite with Matchers {
   test("Borrowing a temporary mutable makes a local var") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Muta { hp int; }
         |fn main() {
@@ -35,7 +35,7 @@ class OwnershipTests extends FunSuite with Matchers {
   }
 
   test("When statement result is an owning ref, calls destructor") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Muta { }
         |
@@ -59,7 +59,7 @@ class OwnershipTests extends FunSuite with Matchers {
   }
 
   test("Saves return value then destroys temporary") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Muta { hp int; }
         |
@@ -82,7 +82,7 @@ class OwnershipTests extends FunSuite with Matchers {
   }
 
   test("Calls destructor on local var") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Muta { }
         |
@@ -107,7 +107,7 @@ class OwnershipTests extends FunSuite with Matchers {
 
   test("Calls destructor on local var unless moved") {
     // Should call the destructor in moo, but not in main
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       """
@@ -149,7 +149,7 @@ class OwnershipTests extends FunSuite with Matchers {
   }
 
   test("Saves return value then destroys local var") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       """
@@ -174,7 +174,7 @@ class OwnershipTests extends FunSuite with Matchers {
   }
 
   test("Gets from temporary struct a member's member") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Wand {
         |  charges int;
@@ -198,7 +198,7 @@ class OwnershipTests extends FunSuite with Matchers {
   test("Checks that we stored a borrowed temporary in a local") {
     // Checking for 2 because one for the temporary, and one inside the
     // templated wrapper function.
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Muta { }
         |fn main() {
@@ -214,7 +214,7 @@ class OwnershipTests extends FunSuite with Matchers {
   }
 
   test("Var RC for one local") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Muta { }
         |fn main() {
@@ -233,7 +233,7 @@ class OwnershipTests extends FunSuite with Matchers {
   }
 
   test("Unstackifies local vars") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  i! = 0;
@@ -254,7 +254,7 @@ class OwnershipTests extends FunSuite with Matchers {
 
 //
 //  test("Moving doesn't affect ref count") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |struct Muta { }
 //        |fn main() {
@@ -268,7 +268,7 @@ class OwnershipTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Wingman catches hanging borrow") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |struct MutaA { }
 //        |struct MutaB {

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/PackTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/PackTests.scala
@@ -8,7 +8,7 @@ import net.verdagon.vale.driver.Compilation
 
 class PackTests extends FunSuite with Matchers {
   test("Extract seq") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  (x, y, z) = [5, 6, 7];
@@ -24,7 +24,7 @@ class PackTests extends FunSuite with Matchers {
   }
 
   test("Nested seqs") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  (x, (y, z)) = [[4, 5], [6, 7]];
@@ -47,7 +47,7 @@ class PackTests extends FunSuite with Matchers {
   }
 
   test("Nested tuples") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  (x, (y, z)) = [5, [6, false]];

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/PatternTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/PatternTests.scala
@@ -11,7 +11,7 @@ import net.verdagon.vale.driver.Compilation
 class PatternTests extends FunSuite with Matchers {
   // To get something like this to work would be rather involved.
   //test("Test matching a single-member pack") {
-  //  val compile = new Compilation("fn main() { [x] = (4); = x; }")
+  //  val compile = Compilation("fn main() { [x] = (4); = x; }")
   //  compile.getTemputs()
   //  val main = temputs.lookupFunction("main")
   //  main.header.returnType shouldEqual Coord(Share, Int2())
@@ -20,7 +20,7 @@ class PatternTests extends FunSuite with Matchers {
 
   test("Test matching a multiple-member seq of immutables") {
     // Checks that the 5 made it into y, and it was an int
-    val compile = new Compilation("fn main() { (x, y) = [4, 5]; = y; }")
+    val compile = Compilation("fn main() { (x, y) = [4, 5]; = y; }")
     val temputs = compile.getTemputs()
     val main = temputs.lookupFunction("main")
     main.header.returnType shouldEqual Coord(Share, Int2())
@@ -29,7 +29,7 @@ class PatternTests extends FunSuite with Matchers {
 
   test("Test matching a multiple-member seq of mutables") {
     // Checks that the 5 made it into y, and it was an int
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine { hp int; }
         |fn main() { (x, y) = [Marine(6), Marine(8)]; = y.hp; }
@@ -42,7 +42,7 @@ class PatternTests extends FunSuite with Matchers {
 
   test("Test matching a multiple-member pack of immutable and own") {
     // Checks that the 5 made it into y, and it was an int
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine { hp int; }
         |fn main() { (x, y) = [7, Marine(8)]; = y.hp; }
@@ -54,7 +54,7 @@ class PatternTests extends FunSuite with Matchers {
 
   test("Test matching a multiple-member pack of immutable and borrow") {
     // Checks that the 5 made it into y, and it was an int
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine { hp int; }
         |fn main() {

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/PrintTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/PrintTests.scala
@@ -5,7 +5,7 @@ import net.verdagon.vale.driver.Compilation
 
 class PrintTests extends FunSuite with Matchers {
   test("Println'ing an int") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  println(6);
@@ -18,7 +18,7 @@ class PrintTests extends FunSuite with Matchers {
   }
 
   test("Println'ing a bool") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  println(true);

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/StringTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/StringTests.scala
@@ -7,7 +7,7 @@ import net.verdagon.vale.driver.Compilation
 
 class StringTests extends FunSuite with Matchers {
   test("Simple string") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  "sprogwoggle"
@@ -21,7 +21,7 @@ class StringTests extends FunSuite with Matchers {
   }
 
   test("String with escapes") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  "sprog\nwoggle"
@@ -35,7 +35,7 @@ class StringTests extends FunSuite with Matchers {
   }
 
   test("String with hex escape") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  "sprog\u001bwoggle"

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/StructTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/StructTests.scala
@@ -7,7 +7,7 @@ import net.verdagon.vale.driver.Compilation
 
 class StructTests extends FunSuite with Matchers {
   test("Make empty mut struct") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine {}
         |fn main() {
@@ -19,13 +19,13 @@ class StructTests extends FunSuite with Matchers {
   }
 
   test("Constructor with this") {
-    val compile = new Compilation(Samples.get("structs/constructor.vale"))
+    val compile = Compilation(Samples.get("structs/constructor.vale"))
 
     compile.evalForReferend(Vector()) shouldEqual VonInt(10)
   }
 
   test("Make struct") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine { hp int; }
         |fn main() {
@@ -37,17 +37,17 @@ class StructTests extends FunSuite with Matchers {
   }
 
   test("Make struct and get member") {
-    val compile = new Compilation(Samples.get("structs/getMember.vale"))
+    val compile = Compilation(Samples.get("structs/getMember.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(9)
   }
 
   test("Mutate struct") {
-    val compile = new Compilation(Samples.get("structs/mutate.vale"))
+    val compile = Compilation(Samples.get("structs/mutate.vale"))
     compile.evalForReferend(Vector()) shouldEqual VonInt(4)
   }
 
   test("Normal destructure") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine {
         |  hp int;
@@ -64,7 +64,7 @@ class StructTests extends FunSuite with Matchers {
   }
 
   test("Sugar destructure") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Marine {
         |  hp int;
@@ -81,7 +81,7 @@ class StructTests extends FunSuite with Matchers {
   }
 
   test("Destroy members at right times") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |struct Weapon { }
         |fn destructor(weapon Weapon) void {
@@ -107,7 +107,7 @@ class StructTests extends FunSuite with Matchers {
 
   // Known failure 2020-08-05
   test("Mutate destroys member after moving it out of the object") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("castutils.vale") +
         Samples.get("printutils.vale") +
       """
@@ -176,7 +176,7 @@ class StructTests extends FunSuite with Matchers {
 
 
   test("Panic function") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface Opt<T> rules(T Ref) { }
         |struct Some<T> rules(T Ref) { value T; }
@@ -204,7 +204,7 @@ class StructTests extends FunSuite with Matchers {
 
 
   test("Call borrow parameter with shared reference") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """fn get<T>(a &T) &T { a }
         |
         |fn main() int {

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/TupleTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/TupleTests.scala
@@ -8,7 +8,7 @@ import net.verdagon.vale.driver.Compilation
 
 class TupleTests extends FunSuite with Matchers {
   test("Simple tuple with one int") {
-    val compile = new Compilation("fn main() { [9].0 }")
+    val compile = Compilation("fn main() { [9].0 }")
 
     val temputs = compile.getTemputs()
     temputs.lookupFunction("main").header.returnType.referend shouldEqual Int2()
@@ -19,7 +19,7 @@ class TupleTests extends FunSuite with Matchers {
   }
 
   test("Tuple with two things") {
-    val compile = new Compilation("fn main() { [9, true].1 }")
+    val compile = Compilation("fn main() { [9, true].1 }")
     compile.evalForReferend(Vector()) shouldEqual VonBool(true)
   }
 

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/VirtualTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/VirtualTests.scala
@@ -9,7 +9,7 @@ import net.verdagon.vale.driver.Compilation
 class VirtualTests extends FunSuite with Matchers {
 
     test("Simple program containing a virtual function") {
-      val compile = new Compilation(
+      val compile = Compilation(
         """
           |interface I {}
           |fn doThing(virtual i I) {4}
@@ -40,7 +40,7 @@ class VirtualTests extends FunSuite with Matchers {
     }
 
   test("Can call virtual function") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface I {}
         |fn doThing(virtual i I) {4}
@@ -72,7 +72,7 @@ class VirtualTests extends FunSuite with Matchers {
   }
 
   test("Can call interface env's function from outside") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |interface I {
         |  fn doThing(virtual i I) int;

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/WeakTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/WeakTests.scala
@@ -12,7 +12,7 @@ import org.scalatest.{FunSuite, Matchers}
 
 class WeakTests extends FunSuite with Matchers {
   test("Make and lock weak ref then destroy own") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
         Samples.get("weaks/lockWhileLive.vale"))
 
@@ -29,7 +29,7 @@ class WeakTests extends FunSuite with Matchers {
   }
 
   test("Destroy own then locking gives none") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
         Samples.get("weaks/dropThenLock.vale"))
 
@@ -37,7 +37,7 @@ class WeakTests extends FunSuite with Matchers {
   }
 
   test("Drop while locked") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
         Samples.get("weaks/dropWhileLocked.vale"))
 
@@ -51,7 +51,7 @@ class WeakTests extends FunSuite with Matchers {
   }
 
   test("Make and lock weak ref from borrow local then destroy own") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
       Samples.get("weaks/weakFromLocalCRef.vale"))
 
@@ -63,7 +63,7 @@ class WeakTests extends FunSuite with Matchers {
   }
 
   test("Make and lock weak ref from borrow then destroy own") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
         Samples.get("weaks/weakFromCRef.vale"))
 
@@ -75,7 +75,7 @@ class WeakTests extends FunSuite with Matchers {
   }
 
   test("Make weak ref from temporary") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
         """
           |struct Muta weakable { hp int; }
@@ -89,7 +89,7 @@ class WeakTests extends FunSuite with Matchers {
   }
 
   test("Cant make weak ref to non-weakable") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
         """
           |struct Muta { hp int; }
@@ -108,7 +108,7 @@ class WeakTests extends FunSuite with Matchers {
   }
 
   test("Cant make weakable extend a non-weakable") {
-    val compile = new Compilation(
+    val compile = Compilation(
       Samples.get("genericvirtuals/opt.vale") +
         """
           |interface IUnit {}

--- a/Valestrom/IntegrationTests/test/net/verdagon/vale/WhileTests.scala
+++ b/Valestrom/IntegrationTests/test/net/verdagon/vale/WhileTests.scala
@@ -6,7 +6,7 @@ import net.verdagon.vale.driver.Compilation
 
 class WhileTests extends FunSuite with Matchers {
   test("Simple while loop that doesnt execute") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  while (false) {}
@@ -18,7 +18,7 @@ class WhileTests extends FunSuite with Matchers {
   }
 
   test("Test a for-ish while loop") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  i! = 0;
@@ -33,7 +33,7 @@ class WhileTests extends FunSuite with Matchers {
   }
 
   test("Tests a while loop with a complex condition") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  key! = 0;
@@ -50,7 +50,7 @@ class WhileTests extends FunSuite with Matchers {
   }
 
   test("Tests a while loop with a != in it") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() {
         |  key! = 0;
@@ -68,7 +68,7 @@ class WhileTests extends FunSuite with Matchers {
   }
 
   test("Return from infinite while loop") {
-    val compile = new Compilation(
+    val compile = Compilation(
       """
         |fn main() int {
         |  while (true) {
@@ -82,7 +82,7 @@ class WhileTests extends FunSuite with Matchers {
   }
 //
 //  test("Tests a while loop with a move in it") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |fn doThings(m: Marine) { }
 //        |struct Marine { hp: int; }

--- a/Valestrom/Samples/src/net/verdagon/vale/Terrain.scala
+++ b/Valestrom/Samples/src/net/verdagon/vale/Terrain.scala
@@ -314,7 +314,7 @@ object Terrain {
         |""".stripMargin
 
   def main(args: Array[String]): Unit = {
-//    val compile = new Compilation(generatorCode)
+//    val compile = Compilation(generatorCode)
 //
 //    val data =
 //      Vivem.executeWithPrimitiveArgs(

--- a/Valestrom/Samples/test/main/resources/generics/arrayutils.vale
+++ b/Valestrom/Samples/test/main/resources/generics/arrayutils.vale
@@ -39,6 +39,15 @@ rules(M Mutability, T Ref, Prot("__call", (&F, int), T))
   Array<M>(n, &IFunction1<mut, int, T>(generator))
 }
 
+fn each<M, N, T, F>(arr &[<M> N * T], func F) void {
+  i! = 0;
+  l = len(&arr);
+  while (i < l) {
+    func(arr[i]);
+    mut i = i + 1;
+  }
+}
+
 fn each<M, T, F>(arr &Array<M, T>, func F) void {
   i! = 0;
   l = len(&arr);

--- a/Valestrom/Samples/test/main/resources/genericvirtuals/hashmap.vale
+++ b/Valestrom/Samples/test/main/resources/genericvirtuals/hashmap.vale
@@ -28,6 +28,19 @@ fn HashMap<K, V, H, E>(hasher H, equator E, capacity int) HashMap<K, V, H, E> {
       0)
 }
 
+fn len<K, V, H, E>(self &HashMap<K, V, H, E>) int { self.size }
+
+fn update<K, V, H, E>(self &HashMap<K, V, H, E>, key K, value V) void {
+  hash int = (self.hasher)(key);
+  startIndex = abs(hash mod self.table.len());
+  index? = findIndexOfKey(self.table, self.equator, startIndex, key);
+  if (index?.empty?()) {
+    panic("Map doesnt have given key!");
+  }
+  node = self.table[index?.get()].get();
+  mut node.value = value;
+}
+
 fn add<K, V, H, E>(map &HashMap<K, V, H, E>, key K, value V) void {
   if (map.has(key)) {
     panic("Map already has given key!");
@@ -133,6 +146,19 @@ fn keys<K, V, H, E>(self &HashMap<K, V, H, E>) Array<imm, K> {
     mut index = index + 1;
   }
   = list.toArray<imm>();
+}
+
+fn values<K, V, H, E>(self &HashMap<K, V, H, E>) Array<mut, V> {
+  list = List<V>();
+  index = 0;
+  while (index < self.table.len()) {
+    node? = self.table[index];
+    if (not(node?.empty?())) {
+      list.add(node?.get().value);
+    }
+    mut index = index + 1;
+  }
+  = list.toArray<mut>();
 }
 
 fn innerRemove<K, V, H, E>(

--- a/Valestrom/Samples/test/main/resources/genericvirtuals/hashset.vale
+++ b/Valestrom/Samples/test/main/resources/genericvirtuals/hashset.vale
@@ -23,11 +23,41 @@ fn HashSet<K, H, E>(hasher H, equator E, capacity int) HashSet<K, H, E> {
       0)
 }
 
+fn HashSet<K, H, E, M, N>(
+    valuesKSA &[<M> N * K],
+    hasher H,
+    equator E)
+HashSet<K, H, E> {
+  this = HashSet<K, H, E>(hasher, equator, 0);
+  each (valuesKSA) (v){
+    if (not this.has(v)) {
+      this.add(v);
+    }
+  }
+  ret this;
+}
+
+fn HashSet<K, H, E, M>(
+    valuesArray &Array<M, K>,
+    hasher H,
+    equator E)
+HashSet<K, H, E> {
+  this = HashSet<K, H, E>(hasher, equator, 0);
+  each (valuesArray) (v){
+    if (not this.has(v)) {
+      this.add(v);
+    }
+  }
+  ret this;
+}
+
 fn len<K, H, E>(set &HashSet<K, H, E>) int { set.size }
+
+fn empty?<K, H, E>(set &HashSet<K, H, E>) bool { set.size == 0 }
 
 fn add<K, H, E>(set &HashSet<K, H, E>, key K) void {
   if (set.has(key)) {
-    panic("Map already has given key!");
+    panic("HashSet already has given key!");
   }
   if ((set.size + 1) * 2 >= set.table.len()) {
     newSize =
@@ -119,7 +149,7 @@ fn has<K, H, E>(self &HashSet<K, H, E>, key K) bool {
   not(self.get(key).empty?())
 }
 
-fn keys<K, H, E>(self &HashSet<K, H, E>) Array<imm, K> {
+fn toArray<K, H, E>(self &HashSet<K, H, E>) Array<imm, K> {
   list = List<K>();
   index = 0;
   while (index < self.table.len()) {
@@ -165,5 +195,19 @@ void {
       mut i = set.table.len(); // break
     }
     mut i = i + 1;
+  }
+}
+
+fn each<K, H, E, F>(
+  self &HashSet<K, H, E>,
+  func F)
+void {
+  index! = 0;
+  while (index < self.table.len()) {
+    node? = self.table[index];
+    if (not(node?.empty?())) {
+      func(node?.get());
+    }
+    mut index = index + 1;
   }
 }

--- a/Valestrom/Samples/test/main/resources/genericvirtuals/opt.vale
+++ b/Valestrom/Samples/test/main/resources/genericvirtuals/opt.vale
@@ -16,7 +16,7 @@ fn get<T>(opt Some<T> impl Opt<T>) T {
 }
 
 fn get<T>(virtual opt &Opt<T>) &T abstract;
-fn get<T>(opt &None<T> impl Opt<T>) &T { panic() }
+fn get<T>(opt &None<T> impl Opt<T>) &T { panic("Called get() on a None!") }
 fn get<T>(opt &Some<T> impl Opt<T>) &T { opt.value }
 
 fn getOr<T>(virtual opt &Opt<T>, default T) T abstract;

--- a/Valestrom/Samples/test/main/resources/genericvirtuals/optingarraylist.vale
+++ b/Valestrom/Samples/test/main/resources/genericvirtuals/optingarraylist.vale
@@ -41,3 +41,12 @@ fn toList<E>(arr &Array<_, E>) List<E> {
   };
   = list;
 }
+
+fn each<E, F>(list &List<E>, func F) void {
+  i! = 0;
+  l = len(&list);
+  while (i < l) {
+    func(list.get(i).get());
+    mut i = i + 1;
+  }
+}

--- a/Valestrom/Samples/test/main/resources/utils.vale
+++ b/Valestrom/Samples/test/main/resources/utils.vale
@@ -43,3 +43,9 @@ fn __call(this &IntHasher, x int) { x }
 
 struct IntEquator { }
 fn __call(this &IntEquator, a int, b int) { a == b }
+
+fn signum(a int) int {
+  = if (a < 0) { -1 }
+    else if (a > 0) { 1 }
+    else { 0 }
+}

--- a/Valestrom/Scout/src/net/verdagon/vale/scout/expressions.scala
+++ b/Valestrom/Scout/src/net/verdagon/vale/scout/expressions.scala
@@ -21,7 +21,7 @@ case class WhileSE(condition: BlockSE, body: BlockSE) extends IExpressionSE
 
 case class ExprMutateSE(mutatee: IExpressionSE, expr: IExpressionSE) extends IExpressionSE
 case class GlobalMutateSE(name: ImpreciseCodeVarNameS, expr: IExpressionSE) extends IExpressionSE
-case class LocalMutateSE(name: IVarNameS, expr: IExpressionSE) extends IExpressionSE
+case class LocalMutateSE(range: RangeS, name: IVarNameS, expr: IExpressionSE) extends IExpressionSE
 
 case class LendSE(innerExpr1: IExpressionSE, targetOwnership: OwnershipP) extends IExpressionSE {
   targetOwnership match {
@@ -98,7 +98,7 @@ case class RepeaterBlockSE(expression: IExpressionSE) extends IExpressionSE
 // Results in a pack, represents the differences between the expressions
 case class RepeaterBlockIteratorSE(expression: IExpressionSE) extends IExpressionSE
 
-case class ReturnSE(inner: IExpressionSE) extends IExpressionSE
+case class ReturnSE(range: RangeS, inner: IExpressionSE) extends IExpressionSE
 case class VoidSE() extends IExpressionSE {}
 
 case class SequenceESE(elements: List[IExpressionSE]) extends IExpressionSE
@@ -131,7 +131,7 @@ case class FunctionCallSE(range: RangeS, callableExpr: IExpressionSE, argsExprs1
 
 case class TemplateSpecifiedLookupSE(name: String, templateArgs: List[ITemplexS]) extends IExpressionSE
 
-case class LocalLoadSE(name: IVarNameS, targetOwnership: OwnershipP) extends IExpressionSE
+case class LocalLoadSE(range: RangeS, name: IVarNameS, targetOwnership: OwnershipP) extends IExpressionSE
 case class FunctionLoadSE(range: RangeS, name: GlobalFunctionFamilyNameS) extends IExpressionSE
 case class RuneLookupSE(rune: IRuneS) extends IExpressionSE
 

--- a/Valestrom/Scout/test/net/verdagon/vale/scout/ScoutTests.scala
+++ b/Valestrom/Scout/test/net/verdagon/vale/scout/ScoutTests.scala
@@ -123,7 +123,7 @@ class ScoutTests extends FunSuite with Matchers {
 
     val CodeBody1(BodySE(_, block)) = main.body
     block match {
-      case BlockSE(_, List(_, FunctionCallSE(_, FunctionLoadSE(_, GlobalFunctionFamilyNameS("shout")), List(LendSE(LocalLoadSE(name, BorrowP), BorrowP))))) => {
+      case BlockSE(_, List(_, FunctionCallSE(_, FunctionLoadSE(_, GlobalFunctionFamilyNameS("shout")), List(LendSE(LocalLoadSE(_,name, BorrowP), BorrowP))))) => {
         name match {
           case CodeVarNameS("x") =>
         }
@@ -137,7 +137,7 @@ class ScoutTests extends FunSuite with Matchers {
 
     val CodeBody1(BodySE(_, block)) = main.body
     block match {
-      case BlockSE(_, List(_, FunctionCallSE(_, FunctionLoadSE(_, GlobalFunctionFamilyNameS("shout")), List(LocalLoadSE(_, OwnP))))) =>
+      case BlockSE(_, List(_, FunctionCallSE(_, FunctionLoadSE(_, GlobalFunctionFamilyNameS("shout")), List(LocalLoadSE(_,_, OwnP))))) =>
     }
   }
 
@@ -195,8 +195,8 @@ class ScoutTests extends FunSuite with Matchers {
           FunctionCallSE(_,
             FunctionLoadSE(_, GlobalFunctionFamilyNameS("MyStruct")),
             List(
-              LocalLoadSE(ConstructingMemberNameS("x"),OwnP),
-              LocalLoadSE(ConstructingMemberNameS("y"),OwnP))))) =>
+              LocalLoadSE(_,ConstructingMemberNameS("x"),OwnP),
+              LocalLoadSE(_,ConstructingMemberNameS("y"),OwnP))))) =>
     }
   }
 
@@ -221,12 +221,12 @@ class ScoutTests extends FunSuite with Matchers {
             IntLiteralSE(4)),
           LetSE(_, _,_,_,
             AtomSP(_,CaptureS(ConstructingMemberNameS("y"),FinalP),None,_,None),
-            LendSE(LocalLoadSE(ConstructingMemberNameS("x"),BorrowP), BorrowP)),
+            LendSE(LocalLoadSE(_,ConstructingMemberNameS("x"),BorrowP), BorrowP)),
           FunctionCallSE(_,
             FunctionLoadSE(_, GlobalFunctionFamilyNameS("MyStruct")),
             List(
-              LocalLoadSE(ConstructingMemberNameS("x"),OwnP),
-              LocalLoadSE(ConstructingMemberNameS("y"),OwnP))))) =>
+              LocalLoadSE(_,ConstructingMemberNameS("x"),OwnP),
+              LocalLoadSE(_,ConstructingMemberNameS("y"),OwnP))))) =>
     }
 
   }
@@ -247,7 +247,7 @@ class ScoutTests extends FunSuite with Matchers {
             List(
               FunctionCallSE(_,
                 FunctionLoadSE(_, GlobalFunctionFamilyNameS("println")),
-                List(DotSE(_, LocalLoadSE(CodeVarNameS("this"),BorrowP),"x",true))),
+                List(DotSE(_, LocalLoadSE(_,CodeVarNameS("this"),BorrowP),"x",true))),
               VoidSE())))) =>
     }
   }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/BlockTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/BlockTemplar.scala
@@ -31,11 +31,10 @@ class BlockTemplar(
     temputs: TemputsBox,
     block1: BlockAE):
   (Block2, Set[Coord]) = {
-    val newCounter = 1
     val fate =
       FunctionEnvironmentBox(
         FunctionEnvironment(
-          parentFate.snapshot, parentFate.fullName, parentFate.function, Map(), parentFate.maybeReturnType, List(), newCounter, List(), Set()))
+          parentFate.snapshot, parentFate.fullName, parentFate.function, Map(), parentFate.maybeReturnType, List(), parentFate.varCounter, List(), Set()))
     val startingFate = fate.snapshot
 
     fate.addScoutedLocals(block1.locals)
@@ -48,6 +47,10 @@ class BlockTemplar(
     // We don't just use the old parentFate because this one might have had moveds added to it.
     val newParentFate @ FunctionEnvironment(_, _, _, _, _, _, _, _, _) = fate.parentEnv
     parentFate.functionEnvironment = newParentFate
+
+    // We may have made some temporary vars in the block, make sure we don't accidentally reuse their numbers,
+    // carry the var counter into the original fate.
+    parentFate.nextCounters(fate.varCounter - parentFate.varCounter)
 
     (block2, returnsFromExprs)
   }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/OverloadTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/OverloadTemplar.scala
@@ -513,7 +513,7 @@ class OverloadTemplar(
       if (bannerByIsBestScore.getOrElse(true, List()).isEmpty) {
         vfail("wat")
       } else if (bannerByIsBestScore.getOrElse(true, List()).size > 1) {
-        vfail("Can't resolve between:\n" + bannerByIsBestScore.mkString("\n"))
+        vfail("Can't resolve between:\n" + bannerByIsBestScore.mapValues(_.mkString("\n")).mkString("\n"))
       } else {
         bannerByIsBestScore(true).head._1
       };

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/PatternTemplar.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/PatternTemplar.scala
@@ -148,7 +148,7 @@ class PatternTemplar(
         // This will mark the variable as moved
         val localLookupExpr =
           localHelper.softLoad(
-            fate, LocalLookup2(export, inputExpr.resultRegister.reference), Own)
+            fate, range, LocalLookup2(range, export, inputExpr.resultRegister.reference), Own)
 
         expectedCoord.referend match {
           case StructRef2(_) => {
@@ -162,7 +162,7 @@ class PatternTemplar(
 
             val innerLets =
               nonCheckingTranslateStructInner(
-                temputs, fate, listOfMaybeDestructureMemberPatterns, expectedCoord, localLookupExpr)
+                temputs, fate, range, listOfMaybeDestructureMemberPatterns, expectedCoord, localLookupExpr)
             (lets0 ++ innerLets)
           }
           case PackT2(_, underlyingStruct @ StructRef2(_)) => {
@@ -170,7 +170,7 @@ class PatternTemplar(
             val reinterpretExpr2 = TemplarReinterpret2(localLookupExpr, structType2)
             val innerLets =
               nonCheckingTranslateStructInner(
-                temputs, fate, listOfMaybeDestructureMemberPatterns, structType2, reinterpretExpr2)
+                temputs, fate, range, listOfMaybeDestructureMemberPatterns, structType2, reinterpretExpr2)
             (lets0 ++ innerLets)
           }
           case TupleT2(_, underlyingStruct @ StructRef2(_)) => {
@@ -178,7 +178,7 @@ class PatternTemplar(
             val reinterpretExpr2 = TemplarReinterpret2(localLookupExpr, structType2)
             val innerLets =
               nonCheckingTranslateStructInner(
-                temputs, fate, listOfMaybeDestructureMemberPatterns, structType2, reinterpretExpr2)
+                temputs, fate, range, listOfMaybeDestructureMemberPatterns, structType2, reinterpretExpr2)
             (lets0 ++ innerLets)
           }
           case KnownSizeArrayT2(size, RawArrayT2(memberType, mutability)) => {
@@ -187,7 +187,7 @@ class PatternTemplar(
             }
             val innerLets =
               nonCheckingTranslateArraySeq(
-                temputs, fate, listOfMaybeDestructureMemberPatterns, localLookupExpr)
+                temputs, fate, range, listOfMaybeDestructureMemberPatterns, localLookupExpr)
             (lets0 ++ innerLets)
           }
           case _ => vfail("impl!")
@@ -315,6 +315,7 @@ class PatternTemplar(
   private def nonCheckingTranslateArraySeq(
     temputs: TemputsBox,
     fate: FunctionEnvironmentBox,
+    range: RangeS,
     innerPatternMaybes: List[AtomAP],
     inputArraySeqExpr: ReferenceExpression2):
   (List[ReferenceExpression2]) = {
@@ -353,7 +354,7 @@ class PatternTemplar(
               case (((innerPattern, memberType), index)) => {
                 val loadExpr =
                   SoftLoad2(
-                    ArraySequenceLookup2(inputArraySeqExpr, arraySeqT, IntLiteral2(index)),
+                    ArraySequenceLookup2(range, inputArraySeqExpr, arraySeqT, IntLiteral2(index)),
                     Share)
                 innerNonCheckingTranslate(temputs, fate, innerPattern, loadExpr)
               }
@@ -376,6 +377,7 @@ class PatternTemplar(
   private def nonCheckingTranslateStructInner(
     temputs: TemputsBox,
     fate: FunctionEnvironmentBox,
+    range: RangeS,
     innerPatternMaybes: List[AtomAP],
     structType2: Coord,
     inputStructExpr: ReferenceExpression2):
@@ -412,7 +414,8 @@ class PatternTemplar(
                 val loadExpr =
                   SoftLoad2(
                     ReferenceMemberLookup2(
-                      SoftLoad2(LocalLookup2(packLocalVariable, structType2), Share),
+                      range,
+                      SoftLoad2(LocalLookup2(range, packLocalVariable, structType2), Share),
                       structDef2.fullName.addStep(structDef2.members(index).name),
                       memberType),
                     Share)

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/TemplarErrorHumanizer.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/TemplarErrorHumanizer.scala
@@ -15,9 +15,17 @@ object TemplarErrorHumanizer {
       err: ICompileErrorT):
   String = {
     err match {
+      case CantMoveOutOfMemberT(range, name) => {
+        humanizePos(filenamesAndSources, range.file, range.begin.offset) +
+          ": Cannot move out of member (" + name + ")"
+      }
       case CannotSubscriptT(range, tyype) => {
         humanizePos(filenamesAndSources, range.file, range.begin.offset) +
           ": Cannot subscript type: " + tyype + "!"
+      }
+      case CouldntConvertForReturnT(range, expectedType, actualType) => {
+        humanizePos(filenamesAndSources, range.file, range.begin.offset) +
+          ": Couldn't convert " + actualType + " to expected return type " + expectedType
       }
       case CouldntFindMemberT(range, memberName) => {
         humanizePos(filenamesAndSources, range.file, range.begin.offset) +

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/TemplarErrorReporter.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/TemplarErrorReporter.scala
@@ -14,6 +14,9 @@ case class CannotSubscriptT(range: RangeS, tyype: Coord) extends ICompileErrorT
 case class CouldntFindFunctionToLoadT(range: RangeS, name: GlobalFunctionFamilyNameA) extends ICompileErrorT
 case class CouldntFindMemberT(range: RangeS, memberName: String) extends ICompileErrorT
 case class BodyResultDoesntMatch(range: RangeS, functionName: IFunctionDeclarationNameA, expectedReturnType: Coord, resultType: Coord) extends ICompileErrorT
+case class CouldntConvertForReturnT(range: RangeS, expectedType: Coord, actualType: Coord) extends ICompileErrorT
+// ("Can't move out of a member!")
+case class CantMoveOutOfMemberT(range: RangeS, name: FullName2[IVarName2]) extends ICompileErrorT
 
 object ErrorReporter {
   def report(err: ICompileErrorT): Nothing = {

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplarCore.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/citizen/StructTemplarCore.scala
@@ -525,6 +525,7 @@ class StructTemplarCore(
         val argExpressions =
           SoftLoad2(
             ReferenceMemberLookup2(
+              range,
               ArgLookup2(
                 0,
                 Coord(

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/function/BuiltInFunctions.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/function/BuiltInFunctions.scala
@@ -58,7 +58,7 @@ object BuiltInFunctions {
               List(LocalVariableA(CodeVarNameA("arr"), FinalP, NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed)),
               List(
                 ArrayLengthAE(
-                  LocalLoadAE(CodeVarNameA("arr"), OwnP))))))),
+                  LocalLoadAE(RangeS.internal(-62),CodeVarNameA("arr"), OwnP))))))),
       FunctionA(
         RangeS.internal(-62),
         FunctionNameA("len", s.CodeLocationS.internal(-21)),
@@ -145,5 +145,5 @@ object BuiltInFunctions {
             BlockAE(
               List(LocalVariableA(CodeVarNameA("weakRef"), FinalP, NotUsed, Used, NotUsed, NotUsed, NotUsed, NotUsed)),
               List(
-                LockWeakAE(RangeS.internal(-91), LocalLoadAE(CodeVarNameA("weakRef"), WeakP))))))))
+                LockWeakAE(RangeS.internal(-91), LocalLoadAE(RangeS.internal(-62),CodeVarNameA("weakRef"), WeakP))))))))
 }

--- a/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererMatcher.scala
+++ b/Valestrom/Templar/src/net/verdagon/vale/templar/infer/InfererMatcher.scala
@@ -470,10 +470,10 @@ class InfererMatcher[Env, State](
           env, state, typeByRune, localRunes, inferences, expectedTemplate, expectedArgs, List(MutabilityTemplata(mutability), CoordTemplata(elementArg)))
       }
       case (CallTT(range, _, _, _), KindTemplata(KnownSizeArrayT2(_, RawArrayT2(_, _)))) => {
-        return (InferMatchConflict(inferences.inferences, range, "Can't match array sequence against anything, no such rule exists", List()))
+        return (InferMatchConflict(inferences.inferences, range, "Can't match array sequence against a CallTT, no such rule exists", List()))
       }
       case (CallTT(range, _, _, _), CoordTemplata(Coord(_, KnownSizeArrayT2(_, _)))) => {
-        return (InferMatchConflict(inferences.inferences, range, "Can't match array sequence against anything, no such rule exists", List()))
+        return (InferMatchConflict(inferences.inferences, range, "Can't match array sequence against a CallTT, no such rule exists", List()))
       }
       case (CallTT(range, expectedTemplate, expectedArgs, resultType), CoordTemplata(Coord(instanceOwnership, UnknownSizeArrayT2(RawArrayT2(elementArg,mutability))))) => {
         vassert(instance.tyype == resultType)

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/TemplarTests.scala
@@ -194,7 +194,7 @@ class TemplarTests extends FunSuite with Matchers {
     val compile = new Compilation("fn main(){a! = 3; mut a = 4; }")
     val temputs = compile.getTemputs();
     val main = temputs.lookupFunction("main")
-    main.only({ case Mutate2(LocalLookup2(ReferenceLocalVariable2(FullName2(_, CodeVarName2("a")), Varying, _), _), IntLiteral2(4)) => })
+    main.only({ case Mutate2(LocalLookup2(_,ReferenceLocalVariable2(FullName2(_, CodeVarName2("a")), Varying, _), _), IntLiteral2(4)) => })
   }
 
   test("Test taking a callable param") {

--- a/Valestrom/Templar/test/net/verdagon/vale/templar/VirtualTests.scala
+++ b/Valestrom/Templar/test/net/verdagon/vale/templar/VirtualTests.scala
@@ -8,7 +8,7 @@ class VirtualTests extends FunSuite with Matchers {
   // TODO: pull all of the templar specific stuff out, the unit test-y stuff
 
 //  test("Simple program containing a virtual function") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I {}
 //        |fn doThing(i: virtual I) {4}
@@ -24,7 +24,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Simple program containing a virtual function taking an interface") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I {}
 //        |struct S {}
@@ -42,7 +42,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Simple override") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I {}
 //        |struct S {}
@@ -67,7 +67,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Two functions overriding another function") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I {}
 //        |struct S1 {}
@@ -86,7 +86,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Function taking an interface overriding another function") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I1 {}
 //        |interface I2 {}
@@ -114,7 +114,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Function taking an interface overriding another function with virtual") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I1 {}
 //        |interface I2 {}
@@ -149,7 +149,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Stamps ancestor structs when we declare a child struct") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |fn dance<T>(i: virtual I<T>) {
@@ -191,7 +191,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Calls an overriding function") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |fn dance<T>(i: virtual I<T>) {
@@ -235,7 +235,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  // So, this checks that it and its three ancestors are all stamped and all get their own
 //  // function families.
 //  test("Stamp multiple function families") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |
@@ -308,7 +308,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  // However, each struct is required to have a vtable entry for that function... they'll all
 //  // point to the original doThing<int>(:I<int>).
 //  test("Stamps virtual functions on a templated interface") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |
@@ -350,7 +350,7 @@ class VirtualTests extends FunSuite with Matchers {
 //
 //
 //  test("Virtual creates function family roots") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |interface J<T> { }
@@ -378,7 +378,7 @@ class VirtualTests extends FunSuite with Matchers {
 //
 //  // Should only be two function families.
 //  test("Override doesnt make a function family root") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface I<T> { }
 //        |interface J<T> { }
@@ -432,7 +432,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  // something different; theyre only distinguished by their template args.
 //
 //  test("Functions with same signatures but different template params make different families") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface MyInterface<T> { }
 //        |fn doThing<T>(x: virtual MyInterface<T>) {}
@@ -455,7 +455,7 @@ class VirtualTests extends FunSuite with Matchers {
 //  }
 //
 //  test("Stamps different families for different template args") {
-//    val compile = new Compilation(
+//    val compile = Compilation(
 //      """
 //        |interface MyInterface<T> { }
 //        |abstract fn doThing<T>(x: virtual MyInterface<T>)Void;

--- a/Valestrom/Templata/src/net/verdagon/vale/templar/expressions.scala
+++ b/Valestrom/Templata/src/net/verdagon/vale/templar/expressions.scala
@@ -1,6 +1,7 @@
 package net.verdagon.vale.templar
 
 import net.verdagon.vale.astronomer.IVarNameA
+import net.verdagon.vale.scout.RangeS
 import net.verdagon.vale.templar.env.{ILocalVariable2, ReferenceLocalVariable2}
 import net.verdagon.vale.templar.templata._
 import net.verdagon.vale.templar.types._
@@ -47,6 +48,8 @@ trait ReferenceExpression2 extends Expression2 {
 trait AddressExpression2 extends Expression2 {
   override def resultRegister: AddressRegister2
   override def referend = resultRegister.reference.referend
+
+  def range: RangeS
 
   // Whether to move-load or borrow-load or weak-load from this expression, if coerced
   // into a reference.
@@ -397,6 +400,7 @@ case class FloatLiteral2(value: Float) extends ReferenceExpression2 {
 }
 
 case class LocalLookup2(
+    range: RangeS,
     localVariable: ILocalVariable2,
     reference: Coord
 ) extends AddressExpression2 {
@@ -436,6 +440,7 @@ case class ArgLookup2(
 //}
 
 case class ArraySequenceLookup2(
+  range: RangeS,
     arrayExpr: ReferenceExpression2,
     arrayType: KnownSizeArrayT2,
     indexExpr: ReferenceExpression2) extends AddressExpression2 {
@@ -451,6 +456,7 @@ case class ArraySequenceLookup2(
 }
 
 case class UnknownSizeArrayLookup2(
+  range: RangeS,
     arrayExpr: ReferenceExpression2,
     arrayType: UnknownSizeArrayT2,
     indexExpr: ReferenceExpression2) extends AddressExpression2 {
@@ -473,6 +479,7 @@ case class ArrayLength2(arrayExpr: ReferenceExpression2) extends ReferenceExpres
 }
 
 case class ReferenceMemberLookup2(
+  range: RangeS,
     structExpr: ReferenceExpression2,
     memberName: FullName2[IVarName2],
     reference: Coord) extends AddressExpression2 {
@@ -485,6 +492,7 @@ case class ReferenceMemberLookup2(
   }
 }
 case class AddressMemberLookup2(
+  range: RangeS,
     structExpr: ReferenceExpression2,
     memberName: FullName2[IVarName2],
     resultType2: Coord) extends AddressExpression2 {

--- a/Valestrom/Utils/src/net/verdagon/vale/SourceCodeUtils.scala
+++ b/Valestrom/Utils/src/net/verdagon/vale/SourceCodeUtils.scala
@@ -44,13 +44,13 @@ object SourceCodeUtils {
     val text = filenamesAndSources(file)._2
     // TODO: can optimize this perhaps
     var lineBegin = 0;
-    while (true) {
+    while (lineBegin < text.length) {
       val lineEnd =
         text.indexOf('\n', lineBegin) match {
           case -1 => text.length
           case other => other
         }
-      if (lineBegin <= position && position < lineEnd) {
+      if (lineBegin <= position && position <= lineEnd) {
         return text.substring(lineBegin, lineEnd)
       }
       lineBegin = lineEnd + 1

--- a/benchmarks/BenchmarkRL/vale/src/game.vale
+++ b/benchmarks/BenchmarkRL/vale/src/game.vale
@@ -29,7 +29,7 @@ fn next(self &!LCGRand) int {
 
 // // Makes a GameMutator that does nothing.
 // pub fn do_nothing_game_mutator() -> GameMutator {
-//     return Box::new(|_rand, _game| {});
+//     ret Box::new(|_rand, _game| {});
 // }
 
 
@@ -42,18 +42,18 @@ struct Game {
 
 // impl Game {
     fn get_current_level(self &Game) &Level {
-        // return &self.levels[self.get_player().level_index];
+        // ret &self.levels[self.get_player().level_index];
         self.levels.get(0).get()
     }
 //     pub fn get_current_level_mut(&mut self) -> &mut Level {
 //         let level_index = self.get_player().level_index;
-//         return &mut self.levels[level_index];
+//         ret &mut self.levels[level_index];
 //     }
 //     pub fn get_player_index(&self) -> generational_arena::Index {
-//         return self.player_index.expect("No player yet!");
+//         ret self.player_index.expect("No player yet!");
 //     }
 //     pub fn get_player(&self) -> &Unit {
-//         return &self.units[self.get_player_index()];
+//         ret &self.units[self.get_player_index()];
 //     }
 
 //     pub fn add_unit_to_level(
@@ -80,7 +80,7 @@ struct Game {
 //             .insert(loc, unit_index);
 //         let unit = &mut self.units[unit_index];
 //         unit.index = Some(unit_index);
-//         return unit_index;
+//         ret unit_index;
 //     }
 
 //     pub fn damage_unit(
@@ -139,7 +139,7 @@ struct Game {
 //     -> &mut T {
 //         let tile = self.get_current_level_mut().tiles.get_mut(&tile_loc).expect("");
 //         let icomponent = tile.components.get_mut(tile_component_index).expect("wat");
-//         return &mut *icomponent.downcast_mut::<T>().expect("");
+//         ret &mut *icomponent.downcast_mut::<T>().expect("");
 //     }
 // }
 
@@ -162,25 +162,29 @@ List<Location> {
     ret result;
 }
 
-// // Get all the locations adjacent to any of the ones in `source_locs`.
-// pub fn get_pattern_locations_adjacent_to_any(
-//     source_locs: &FxHashSet<Location>,
-//     include_source_locs: bool,
-//     consider_corners_adjacent: bool,
-// ) -> FxHashSet<Location> {
-//     let mut result = FxHashSet::default();
-//     for &original_location in source_locs {
-//         let mut adjacents =
-//             get_pattern_adjacent_locations(original_location, consider_corners_adjacent);
-//         if include_source_locs {
-//             adjacents.push(original_location.clone());
-//         }
-//         for adjacent_location in adjacents {
-//             if !include_source_locs && source_locs.contains(&adjacent_location) {
-//                 continue;
-//             }
-//             result.insert(adjacent_location);
-//         }
-//     }
-//     return result;
-// }
+// Get all the locations adjacent to any of the ones in `source_locs`.
+fn get_pattern_locations_adjacent_to_any(
+    source_locs &HashSet<Location, LocationHasher, LocationEquator>,
+    include_source_locs bool,
+    consider_corners_adjacent bool)
+HashSet<Location, LocationHasher, LocationEquator> {
+    result =
+        HashSet<Location, LocationHasher, LocationEquator>(
+            LocationHasher(), LocationEquator());
+    each (source_locs) (original_location){
+        adjacents =
+            get_pattern_adjacent_locations(original_location, consider_corners_adjacent);
+        if (include_source_locs) {
+            adjacents.add(original_location);
+        }
+        each (&adjacents) (adjacent_location){
+            if (include_source_locs or not source_locs.has(adjacent_location)) {
+                // DIFFERENCE our set doesnt let you insert if already there
+                if (not result.has(adjacent_location)) {
+                    result.add(adjacent_location);
+                }
+            }
+        }
+    }
+    ret result;
+}

--- a/benchmarks/BenchmarkRL/vale/src/location.vale
+++ b/benchmarks/BenchmarkRL/vale/src/location.vale
@@ -19,6 +19,11 @@ fn str(loc Location) {
     "(" + str(loc.x) + ", " + str(loc.y) + ")"
 }
 
+// Added
+fn ==(a Location, b Location) bool {
+    a.x == b.x and a.y == b.y
+}
+
 struct Location imm {
     x int;
     y int;

--- a/benchmarks/BenchmarkRL/vale/src/main.vale
+++ b/benchmarks/BenchmarkRL/vale/src/main.vale
@@ -68,13 +68,14 @@
 // }
 
 
+struct MyBoxx { i int; b bool; }
 
 fn main() {
-  seed = 1337;// DIFFERENCE
+  seed = 44;// DIFFERENCE
   benchmark_rl(
     seed,
-    36,
-    18,
+    30,
+    20,
     10,
     true,
     100);

--- a/benchmarks/BenchmarkRL/vale/src/make_level.vale
+++ b/benchmarks/BenchmarkRL/vale/src/make_level.vale
@@ -83,9 +83,7 @@ Level {
             loc = Location(x, y);
             walkable = walkabilities.get(x).get().get(y).get();
             on_edge = x == 0 or y == 0 or x == max_width - 1 or y == max_height - 1;
-            // println(str(loc) + " w " + str(walkable) + " e " + str(on_edge));
             if (walkable and not on_edge) {
-                // println("adding floor");
                 display_class =
                   if (rand.next() mod 2 == 0) {
                     "dirt"
@@ -119,7 +117,6 @@ Level {
                     mut neighbor_x = neighbor_x + 1;
                 }
 
-                // println("adding wall");
                 if (next_to_walkable) {
                     level.tiles.add(
                         loc,
@@ -205,12 +202,17 @@ fn connect_all_rooms(
     consider_corners_adjacent bool) void {
     rooms = identify_rooms(&walkabilities, consider_corners_adjacent);
     connect_rooms(&rand, &rooms);
-    // for i in 0..rooms.len() {
-    //     let new_room = &rooms[i];
-    //     for loc in new_room {
-    //         walkabilities[loc.x as usize][loc.y as usize] = true;
-    //     }
-    // }
+
+    i! = 0;
+    while (i < rooms.len()) {
+        new_room = rooms.get(i).get();
+
+        each (new_room) (loc){
+            walkabilities.get(loc.x).get().set(loc.y, true);
+        }
+
+        mut i = i + 1;
+    }
     0;
 }
 
@@ -237,7 +239,7 @@ List<HashSet<Location, LocationHasher, LocationEquator>> {
                             consider_corners_adjacent,
                             spark_location);
                     new_room_index = rooms.len();
-                    connected_locations_clone = connected_locations.keys();
+                    connected_locations_clone = connected_locations.toArray();
                     rooms.add(connected_locations); // DIFFERENCE clones
 
                     i! = 0;
@@ -274,9 +276,9 @@ HashSet<Location, LocationHasher, LocationEquator> {
     connected_with_unexplored_neighbors.add(start_location);
 
     while (connected_with_unexplored_neighbors.len() > 0) {
-        // DIFFERENCE they use iter we use keys()
+        // DIFFERENCE they use iter we use toArray()
         current =
-            connected_with_unexplored_neighbors.keys()[0];
+            connected_with_unexplored_neighbors.toArray()[0];
         assert(not connected_with_explored_neighbors.has(current));
 
         connected_with_unexplored_neighbors.remove(current);
@@ -316,7 +318,7 @@ fn connect_rooms(
         room = rooms.get(room_index).get();
         i! = 0;
         // DIFFERENCE
-        room_keys = room.keys();
+        room_keys = room.toArray();
         while (i < room_keys.len()) {
             room_floor_loc = room_keys[i];
 
@@ -351,110 +353,152 @@ fn connect_rooms(
         mut room_index = room_index + 1;
     }
 
-//     loop {
+    outer_running! = true;
+    while (outer_running) {
         // DIFFERENCE
-        distinct_regions_keys = region_by_room_index.keys();
-        if (distinct_regions_keys.len() >= 2) {
-            region_a = distinct_regions_keys[0];
-            region_b = distinct_regions_keys[1];
+        distinct_regions =
+            HashSet<int, IntHasher, IntEquator>(
+                &region_by_room_index.values(),
+                IntHasher(), IntEquator());
 
-            // let region_a_room_index =
-            //     *get_hash_set_random_nth(&mut rand, &room_indices_by_region_num[&region_a])
-            //         .expect("wat");
-            // let region_a_room = &rooms[region_a_room_index];
-            // let region_a_location = *get_hash_set_random_nth(&mut rand, &region_a_room).expect("wat");
 
-            // let region_b_room_index =
-            //     *get_hash_set_random_nth(&mut rand, &room_indices_by_region_num[&region_b])
-            //         .expect("wat");
-            // let region_b_room = &rooms[region_b_room_index];
-            // let region_b_location = *get_hash_set_random_nth(&mut rand, &region_b_room).expect("wat");
+        if (distinct_regions.len() >= 2) {
+            distinct_regions_arr = distinct_regions.toArray();
+            region_a = distinct_regions_arr[0];
+            region_b = distinct_regions_arr[1];
 
-            // // Now lets drive from region_a_location to region_b_location, and see what happens on the
-            // // way there.
-            // let mut path = Vec::new();
-            // let mut current_location = region_a_location;
-            // while current_location != region_b_location {
-            //     if current_location.x != region_b_location.x {
-            //         current_location.x += (region_b_location.x - current_location.x).signum();
-            //     } else if current_location.y != region_b_location.y {
-            //         current_location.y += (region_b_location.y - current_location.y).signum();
-            //     } else {
-            //         panic!("wat")
-            //     }
-            //     if !room_index_by_location.contains_key(&current_location) {
-            //         // It means we're in open space, keep going.
-            //         path.push(current_location);
-            //     } else {
-            //         let current_room_index = room_index_by_location[&current_location];
-            //         let current_region = region_by_room_index[&current_room_index];
-            //         if current_region == region_a {
-            //             // Keep going, but restart the path here.
-            //             path = Vec::new();
-            //         } else if current_region != region_a {
-            //             // current_regionNumber is probably region_bNumber, but isn't necessarily... we could
-            //             // have just come across a random other region.
-            //             // Either way, we hit something, so we stop now.
-            //             break;
-            //         }
-            //     }
-            // }
+            region_a_room_index =
+                get_hash_set_random_nth(&rand, &room_indices_by_region_num.get(region_a)^.get()).get();
+            region_a_room = &rooms.get(region_a_room_index).get();
+            region_a_location = get_hash_set_random_nth(&rand, &region_a_room).get();
 
-            // let combined_region = regions.len();
-            // regions.insert(combined_region);
+            room_indices_by_region_num.get(region_b);
+            room_indices_by_region_num.get(region_b)^.get();
+            room_indices_by_region_num.get(region_b)^.get().len();
 
-            // let new_room_index = rooms.len();
-            // rooms.push(FxHashSet::from_iter(path.iter().cloned()));
-            // for path_location in &path {
-            //     room_index_by_location.insert(*path_location, new_room_index);
-            // }
-            // region_by_room_index.insert(new_room_index, combined_region);
-            // // We'll fill in regionNumberByRoomIndex and room_indices_by_region_num. umber shortly.
+            region_b_room_index =
+                get_hash_set_random_nth(&rand, &room_indices_by_region_num.get(region_b)^.get()).get();
+            region_b_room = &rooms.get(region_b_room_index).get();
+            region_b_location = get_hash_set_random_nth(&rand, &region_b_room).get();
 
-            // // So, now we have a path that we know connects some regions. However, it might be
-            // // accidentally connecting more than two! It could have grazed past another region without
-            // // us realizing it.
-            // // So now, figure out all the regions that this path touches.
+            // Now lets drive from region_a_location to region_b_location, and see what happens on the
+            // way there.
+            path! = List<Location>();
+            current_location! = region_a_location;
+            running! = true;
+            while (running and current_location != region_b_location) {
+                if (current_location.x != region_b_location.x) {
+                    // DIFFERENCE! make sure its optimized out
+                    mut current_location =
+                        Location(
+                            current_location.x + (region_b_location.x - current_location.x).signum(),
+                            current_location.y);
+                } else if (current_location.y != region_b_location.y) {
+                    // DIFFERENCE! make sure its optimized out
+                    mut current_location =
+                        Location(
+                            current_location.x,
+                            current_location.y + (region_b_location.y - current_location.y).signum());
+                } else {
+                    panic("wat");
+                }
+                if (not room_index_by_location.has(current_location)) {
+                    // It means we're in open space, keep going.
+                    path.add(current_location);
+                } else {
+                    current_room_index = room_index_by_location.get(current_location).get();
+                    current_region = region_by_room_index.get(current_room_index).get();
+                    if (current_region == region_a) {
+                        // DIFFERENCE rust overwrites but we make a new thing.
+                        // Keep going, but restart the path here.
+                        mut path = List<Location>();
+                    } else if (current_region != region_a) {
+                        // current_regionNumber is probably region_bNumber, but isn't necessarily... we could
+                        // have just come across a random other region.
+                        // Either way, we hit something, so we stop now.
+                        mut running = false;
+                    }
+                }
+            }
 
-            // let path_adjacent_locations = get_pattern_locations_adjacent_to_any(
-            //     &FxHashSet::from_iter(path.iter().cloned()),
-            //     true,
-            //     false,
-            // );
-            // let mut path_adjacent_regions = FxHashSet::default();
-            // for path_adjacent_location in path_adjacent_locations {
-            //     if room_index_by_location.contains_key(&path_adjacent_location) {
-            //         let room_index = room_index_by_location[&path_adjacent_location];
-            //         let region = region_by_room_index[&room_index];
-            //         path_adjacent_regions.insert(region);
-            //     }
-            // }
+            combined_region = regions.len();
+            regions.add(combined_region);
 
-            // let mut room_indices_in_combined_region = FxHashSet::default();
-            // room_indices_in_combined_region.insert(new_room_index);
-            // for path_adjacent_region in path_adjacent_regions {
-            //     if path_adjacent_region == combined_region {
-            //         // The new room is already part of this region
-            //         continue;
-            //     }
-            //     for path_adjacent_room_index in &room_indices_by_region_num[&path_adjacent_region] {
-            //         region_by_room_index.insert(*path_adjacent_room_index, combined_region);
-            //         room_indices_in_combined_region.insert(*path_adjacent_room_index);
-            //     }
-            //     room_indices_by_region_num.remove(&path_adjacent_region);
-            // }
-            // room_indices_by_region_num.insert(combined_region, room_indices_in_combined_region.clone());
+            new_room_index = rooms.len();
+            // DIFFERENCE
+            rooms.add(
+                HashSet<Location, LocationHasher, LocationEquator>(
+                    &path.toArray<mut>(), LocationHasher(), LocationEquator()));
+            each (&path) (path_location){
+                room_index_by_location.add(path_location, new_room_index);
+            }
+            region_by_room_index.add(new_room_index, combined_region);
+            // We'll fill in regionNumberByRoomIndex and room_indices_by_region_num. umber shortly.
+
+            // So, now we have a path that we know connects some regions. However, it might be
+            // accidentally connecting more than two! It could have grazed past another region without
+            // us realizing it.
+            // So now, figure out all the regions that this path touches.
+
+
+            path_adjacent_locations =
+                get_pattern_locations_adjacent_to_any(
+                    &HashSet<Location, LocationHasher, LocationEquator>(
+                        &path.toArray<mut>(), LocationHasher(), LocationEquator()),
+                    true,
+                    false);
+            path_adjacent_regions =
+                HashSet<int, IntHasher, IntEquator>(
+                    IntHasher(), IntEquator());
+            each (&path_adjacent_locations) (path_adjacent_location){
+                if (&room_index_by_location has path_adjacent_location) {
+                    room_index = room_index_by_location.get(path_adjacent_location).get();
+                    region = region_by_room_index.get(room_index).get();
+                    // DIFFERENCE we check if its already there
+                    if (not path_adjacent_regions.has(region)) {
+                        path_adjacent_regions.add(region);
+                    }
+                }
+            }
+
+            room_indices_in_combined_region =
+                HashSet<int, IntHasher, IntEquator>(
+                    IntHasher(), IntEquator());
+            room_indices_in_combined_region.add(new_room_index);
+            each (&path_adjacent_regions) (path_adjacent_region){
+                // Otherwise the new room is already part of this region
+                if (path_adjacent_region != combined_region) {
+                    each (room_indices_by_region_num.get(path_adjacent_region)^.get()) (path_adjacent_room_index){
+                        // DIFFERENCE we're calling update here
+                        region_by_room_index.update(path_adjacent_room_index, combined_region);
+                        room_indices_in_combined_region.add(path_adjacent_room_index);
+                    }
+                    room_indices_by_region_num.remove(path_adjacent_region);
+                }
+            }
+            // DIFFERENCE they had a clone?
+            room_indices_by_region_num.add(combined_region, room_indices_in_combined_region);
 
             // room_indices_by_region_num.insert(combined_region, room_indices_in_combined_region);
+        } else {
+            mut outer_running = false;
         }
-//     }
+    }
 
     0;
 }
 
-// fn get_hash_set_random_nth<'a, T>(rand: &mut LCGRand, set: &'a FxHashSet<T>) -> Option<&'a T> {
-//     ret set.iter().nth((rand.next() as usize) % set.len());
-// }
+fn get_hash_set_random_nth<T, H, E>(
+    rand &!LCGRand,
+    set &HashSet<T, H, E>)
+Opt<T> {
+    if (set.empty?()) {
+        result Opt<T> = None<T>();
+        ret result;
+    }
+    keys = set.toArray();
+    ret Some(keys[rand.next() mod keys.len()]);
+}
 
 fn get_adjacent_locations(
     width int,


### PR DESCRIPTION
Finished terrain generation for BenchmarkRL-vale
Fixed constraint violation printout
Made Midas count how many RC access and how many generation accesses there are
Added HashMap.update, HashMap.len, HashMap.values, HashSet constructors from arrays, HashSet.empty, HashSet.toArray, HashSet.each, List.each, int.signum, 
Made None's .get() print something out
Added errors for moving out of a member and not being able to convert to expected return value